### PR TITLE
Ready prod

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.0.5',
+    version='0.0.6',
     description='Sewer is a programmatic Lets Encrypt(ACME) client',
     long_description=long_description,
 

--- a/sewer/ACMEclient.py
+++ b/sewer/ACMEclient.py
@@ -60,8 +60,8 @@ class ACMEclient(object):
             digest='sha256',
             ACME_REQUEST_TIMEOUT=65,
             ACME_CHALLENGE_WAIT_PERIOD=4,
-            GET_NONCE_URL="https://acme-staging.api.letsencrypt.org/directory",
-            ACME_CERTIFICATE_AUTHORITY_URL="https://acme-staging.api.letsencrypt.org",
+            GET_NONCE_URL="https://acme-v01.api.letsencrypt.org/directory",
+            ACME_CERTIFICATE_AUTHORITY_URL="https://acme-v01.api.letsencrypt.org",
             ACME_CERTIFICATE_AUTHORITY_TOS='https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf',
             ACME_CERTIFICATE_AUTHORITY_CHAIN='https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem',
             CLOUDFLARE_API_BASE_URL='https://api.cloudflare.com/client/v4/'):
@@ -103,9 +103,9 @@ class ACMEclient(object):
             ACME_CERTIFICATE_AUTHORITY_URL=self.ACME_CERTIFICATE_AUTHORITY_URL,
             CLOUDFLARE_API_BASE_URL=self.CLOUDFLARE_API_BASE_URL)
 
-        # for production/live use:
-        # self.GET_NONCE_URL = "https://acme-v01.api.letsencrypt.org/directory"
-        # self.ACME_CERTIFICATE_AUTHORITY_URL = "https://acme-v01.api.letsencrypt.org"
+        # for staging/test, use:
+        # GET_NONCE_URL="https://acme-staging.api.letsencrypt.org/directory",
+        # ACME_CERTIFICATE_AUTHORITY_URL="https://acme-staging.api.letsencrypt.org"
 
     def create_account_key(self):
         self.logger.info('create_account_key')


### PR DESCRIPTION
Thank you for contributing to sewer.                    
Every contribution to sewer is as important to us.                       
You may not know it, but you have just contributed to making the world a more safer and secure place.                         

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to sewer, and sewer agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that sewer shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

## What(What have you changed?)
- change letsencrypt urls to production ones

## Why(Why did you change it?)
- make customers experience smooth. By default, customers should do as little as possible to get certificates. That means, they do not have to configure urls.
