### PR TITLE
Dns provider agnostic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,11 @@
+import os
+
 from setuptools import setup
 # To use a consistent encoding
 import codecs
+
+here = os.path.abspath(os.path.dirname(__file__))
+about = {}
 
 try:
     import pypandoc
@@ -8,25 +13,28 @@ try:
 except ImportError:
     long_description = codecs.open('README.md').read()
 
+with open(os.path.join(here, 'sewer', '__version__.py'), 'r') as f:
+    exec (f.read(), about)
+
 setup(
-    name='sewer',
+    name=about['__title__'],
 
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.0.7',
-    description='Sewer is a programmatic Lets Encrypt(ACME) client',
+    version=about['__version__'],
+    description=about['__description__'],
     long_description=long_description,
 
     # The project's main homepage.
-    url='https://github.com/komuW/sewer',
+    url=about['__url__'],
 
     # Author details
-    author='komuW',
-    author_email='komuw05@gmail.com',
+    author=about['__author__'],
+    author_email=about['__author_email__'],
 
     # Choose your license
-    license='MIT',
+    license=about['__license__'],
 
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[

--- a/sewer/ACMEclient.py
+++ b/sewer/ACMEclient.py
@@ -113,11 +113,12 @@ class ACMEclient(object):
 
     def get_user_agent(self):
         # TODO: add the sewer-acme versionto the User-Agent
-        return "python-requests/{requests_version} ({system}: {machine}) sewer-acme {sewer_version}".format(
+        return "python-requests/{requests_version} ({system}: {machine}) sewer {sewer_version} ({sewer_url})".format(
             requests_version=requests.__version__,
             system=platform.system(),
             machine=platform.machine(),
-            sewer_version=sewer_version.__version__)
+            sewer_version=sewer_version.__version__,
+            sewer_url=sewer_version.__url__)
 
     def create_account_key(self):
         self.logger.info('create_account_key')

--- a/sewer/ACMEclient.py
+++ b/sewer/ACMEclient.py
@@ -12,6 +12,8 @@ import OpenSSL
 import Crypto.PublicKey.RSA
 from structlog import get_logger
 
+import __version__ as sewer_version
+
 
 class ACMEclient(object):
     """
@@ -111,10 +113,11 @@ class ACMEclient(object):
 
     def get_user_agent(self):
         # TODO: add the sewer-acme versionto the User-Agent
-        return "python-requests/{requests_version} ({system}: {machine}) sewer-acme".format(
+        return "python-requests/{requests_version} ({system}: {machine}) sewer-acme {sewer_version}".format(
             requests_version=requests.__version__,
             system=platform.system(),
-            machine=platform.machine())
+            machine=platform.machine(),
+            sewer_version=sewer_version.__version__)
 
     def create_account_key(self):
         self.logger.info('create_account_key')

--- a/sewer/ACMEclient.py
+++ b/sewer/ACMEclient.py
@@ -20,11 +20,14 @@ class ACMEclient(object):
     todo: improve documentation.
 
     usage:
+        from dns_providers import cloudflare
+        dns_class = cloudflare.CloudFlareDns(CLOUDFLARE_DNS_ZONE_ID='random',
+                                             CLOUDFLARE_EMAIL='example@example.com',
+                                             CLOUDFLARE_API_KEY='nsa-grade-api-key')
+
         1. to create a new certificate.
         client = ACMEclient(domain_name='example.com',
-                            CLOUDFLARE_DNS_ZONE_ID='random',
-                            CLOUDFLARE_EMAIL='example@example.com',
-                            CLOUDFLARE_API_KEY='nsa-grade-api-key')
+                            dns_class=dns_class)
         certificate = client.cert()
         certificate_key = client.certificate_key
         account_key = client.account_key
@@ -41,9 +44,7 @@ class ACMEclient(object):
             account_key = account_key_file.read()
 
         client = ACMEclient(domain_name='example.com',
-                            CLOUDFLARE_DNS_ZONE_ID='random',
-                            CLOUDFLARE_EMAIL='example@example.com',
-                            CLOUDFLARE_API_KEY='nsa-grade-api-key',
+                            dns_class=dns_class,
                             account_key=account_key)
         certificate = client.renew()
         certificate_key = client.certificate_key
@@ -55,9 +56,7 @@ class ACMEclient(object):
     def __init__(
             self,
             domain_name,
-            CLOUDFLARE_DNS_ZONE_ID,
-            CLOUDFLARE_EMAIL,
-            CLOUDFLARE_API_KEY,
+            dns_class,
             account_key=None,
             bits=2048,
             digest='sha256',
@@ -66,16 +65,14 @@ class ACMEclient(object):
             GET_NONCE_URL="https://acme-v01.api.letsencrypt.org/directory",
             ACME_CERTIFICATE_AUTHORITY_URL="https://acme-v01.api.letsencrypt.org",
             ACME_CERTIFICATE_AUTHORITY_TOS='https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf',
-            ACME_CERTIFICATE_AUTHORITY_CHAIN='https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem',
-            CLOUDFLARE_API_BASE_URL='https://api.cloudflare.com/client/v4/'):
+            ACME_CERTIFICATE_AUTHORITY_CHAIN='https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem'
+    ):
 
         self.logger = get_logger(__name__).bind(
             client_name=self.__class__.__name__)
 
         self.domain_name = domain_name
-        self.CLOUDFLARE_DNS_ZONE_ID = CLOUDFLARE_DNS_ZONE_ID
-        self.CLOUDFLARE_EMAIL = CLOUDFLARE_EMAIL
-        self.CLOUDFLARE_API_KEY = CLOUDFLARE_API_KEY
+        self.dns_class = dns_class
         self.bits = bits
         self.digest = digest
         self.ACME_REQUEST_TIMEOUT = ACME_REQUEST_TIMEOUT
@@ -84,10 +81,10 @@ class ACMEclient(object):
         self.ACME_CERTIFICATE_AUTHORITY_URL = ACME_CERTIFICATE_AUTHORITY_URL
         self.ACME_CERTIFICATE_AUTHORITY_TOS = ACME_CERTIFICATE_AUTHORITY_TOS
         self.ACME_CERTIFICATE_AUTHORITY_CHAIN = ACME_CERTIFICATE_AUTHORITY_CHAIN
+        self.User_Agent = self.get_user_agent()
         self.certificate_key = self.create_certificate_key()
         self.csr = self.create_csr()
         self.certificate_chain = self.get_certificate_chain()
-        self.User_Agent = self.get_user_agent()
 
         if not account_key:
             self.account_key = self.create_account_key()
@@ -96,16 +93,10 @@ class ACMEclient(object):
             self.account_key = account_key
             self.PRIOR_REGISTERED = True
 
-        if CLOUDFLARE_API_BASE_URL[-1] != '/':
-            self.CLOUDFLARE_API_BASE_URL = CLOUDFLARE_API_BASE_URL + '/'
-        else:
-            self.CLOUDFLARE_API_BASE_URL = CLOUDFLARE_API_BASE_URL
-
         self.logger = self.logger.bind(
             client_name=self.__class__.__name__,
             domain_name=self.domain_name,
-            ACME_CERTIFICATE_AUTHORITY_URL=self.ACME_CERTIFICATE_AUTHORITY_URL,
-            CLOUDFLARE_API_BASE_URL=self.CLOUDFLARE_API_BASE_URL)
+            ACME_CERTIFICATE_AUTHORITY_URL=self.ACME_CERTIFICATE_AUTHORITY_URL)
 
         # for staging/test, use:
         # GET_NONCE_URL="https://acme-staging.api.letsencrypt.org/directory",
@@ -283,28 +274,6 @@ class ACMEclient(object):
 
         return acme_keyauthorization, base64_of_acme_keyauthorization
 
-    def create_cloudflare_dns_record(self, base64_of_acme_keyauthorization):
-        self.logger.info('create_cloudflare_dns_record')
-        url = urlparse.urljoin(
-            self.CLOUDFLARE_API_BASE_URL,
-            'zones/{0}/dns_records'.format(self.CLOUDFLARE_DNS_ZONE_ID))
-        headers = {
-            'X-Auth-Email': self.CLOUDFLARE_EMAIL,
-            'X-Auth-Key': self.CLOUDFLARE_API_KEY,
-            'Content-Type': 'application/json'
-        }
-        body = {
-            "type": "TXT",
-            "name": '_acme-challenge' + '.' + self.domain_name,
-            "content": "{0}".format(base64_of_acme_keyauthorization)
-        }
-        create_cloudflare_dns_record_response = requests.post(
-            url,
-            headers=headers,
-            data=json.dumps(body),
-            timeout=self.ACME_REQUEST_TIMEOUT)
-        return create_cloudflare_dns_record_response
-
     def notify_acme_challenge_set(self, acme_keyauthorization,
                                   dns_challenge_url):
         self.logger.info('notify_acme_challenge_set')
@@ -316,7 +285,8 @@ class ACMEclient(object):
             dns_challenge_url, payload)
         return notify_acme_challenge_set_response
 
-    def check_challenge_status(self, dns_record_id, dns_challenge_url):
+    def check_challenge_status(self, dns_record_id, dns_challenge_url,
+                               base64_of_acme_keyauthorization):
         self.logger.info('check_challenge')
         time.sleep(self.ACME_CHALLENGE_WAIT_PERIOD)
         while True:
@@ -334,23 +304,10 @@ class ACMEclient(object):
             if challenge_status == "pending":
                 time.sleep(self.ACME_CHALLENGE_WAIT_PERIOD)
             elif challenge_status == "valid":
-                self.delete_cloudflare_dns_record(dns_record_id=dns_record_id)
+                self.dns_class.delete_dns_record(
+                    self.domain_name, base64_of_acme_keyauthorization)
                 break
         return check_challenge_status_response
-
-    def delete_cloudflare_dns_record(self, dns_record_id):
-        self.logger.info('delete_cloudflare_dns_record')
-        url = urlparse.urljoin(self.CLOUDFLARE_API_BASE_URL,
-                               'zones/{0}/dns_records/{1}'.format(
-                                   self.CLOUDFLARE_DNS_ZONE_ID, dns_record_id))
-        headers = {
-            'X-Auth-Email': self.CLOUDFLARE_EMAIL,
-            'X-Auth-Key': self.CLOUDFLARE_API_KEY,
-            'Content-Type': 'application/json'
-        }
-        response = requests.delete(
-            url, headers=headers, timeout=self.ACME_REQUEST_TIMEOUT)
-        return response
 
     def get_certicate(self):
         self.logger.info('get_certicate')
@@ -378,12 +335,13 @@ class ACMEclient(object):
         dns_token, dns_challenge_url = self.get_challenge()
         acme_keyauthorization, base64_of_acme_keyauthorization = self.get_keyauthorization(
             dns_token)
-        create_cloudflare_dns_record_response = self.create_cloudflare_dns_record(
-            base64_of_acme_keyauthorization)
+        create_cloudflare_dns_record_response = self.dns_class.create_dns_record(
+            self.domain_name, base64_of_acme_keyauthorization)
         self.notify_acme_challenge_set(acme_keyauthorization, dns_challenge_url)
         dns_record_id = create_cloudflare_dns_record_response.json()['result'][
             'id']
-        self.check_challenge_status(dns_record_id, dns_challenge_url)
+        self.check_challenge_status(dns_record_id, dns_challenge_url,
+                                    base64_of_acme_keyauthorization)
         certificate = self.get_certicate()
 
         return certificate

--- a/sewer/__version__.py
+++ b/sewer/__version__.py
@@ -1,6 +1,7 @@
 __title__ = "sewer"
-__description__ = "Sewer is a Let's Encrypt(ACME) client."
+__description__ = "Sewer is a programmatic Lets Encrypt(ACME) client"
 __url__ = "https://github.com/komuW/sewer"
 __version__ = "0.0.7"
 __author__ = "komuW"
 __author_email__ = "komuw05@gmail.com"
+__license__ = "MIT"

--- a/sewer/__version__.py
+++ b/sewer/__version__.py
@@ -1,0 +1,6 @@
+__title__ = "sewer"
+__description__ = "Sewer is a Let's Encrypt(ACME) client."
+__url__ = "https://github.com/komuW/sewer"
+__version__ = "0.0.7"
+__author__ = "komuW"
+__author_email__ = "komuw05@gmail.com"

--- a/sewer/__version__.py
+++ b/sewer/__version__.py
@@ -1,7 +1,7 @@
 __title__ = "sewer"
 __description__ = "Sewer is a programmatic Lets Encrypt(ACME) client"
 __url__ = "https://github.com/komuW/sewer"
-__version__ = "0.0.7"
+__version__ = "0.0.8"
 __author__ = "komuW"
 __author_email__ = "komuw05@gmail.com"
 __license__ = "MIT"

--- a/sewer/cli.py
+++ b/sewer/cli.py
@@ -60,27 +60,36 @@ def main():
     args = parser.parse_args()
     logger = get_logger(__name__)
 
-    # TODO: enable this when sewer becomes dns provider agnostic
-    # dns_provider = args.dns
+    dns_provider = args.dns
     domains = args.domains
     action = args.action
     account_key = args.account_key
     if account_key:
         account_key = account_key.read()
-    try:
-        CLOUDFLARE_EMAIL = os.environ['CLOUDFLARE_EMAIL']
-        CLOUDFLARE_API_KEY = os.environ['CLOUDFLARE_API_KEY']
-        CLOUDFLARE_DNS_ZONE_ID = os.environ['CLOUDFLARE_DNS_ZONE_ID']
-    except KeyError as e:
-        logger.info("ERROR:: Please supply {0} as an environment variable.".
-                    format(str(e)))
+
+    if dns_provider == 'cloudflare':
+        from dns_providers import cloudflare
+        try:
+            CLOUDFLARE_EMAIL = os.environ['CLOUDFLARE_EMAIL']
+            CLOUDFLARE_API_KEY = os.environ['CLOUDFLARE_API_KEY']
+            CLOUDFLARE_DNS_ZONE_ID = os.environ['CLOUDFLARE_DNS_ZONE_ID']
+
+            dns_class = cloudflare.CloudFlareDns(
+                CLOUDFLARE_DNS_ZONE_ID=CLOUDFLARE_DNS_ZONE_ID,
+                CLOUDFLARE_EMAIL=CLOUDFLARE_EMAIL,
+                CLOUDFLARE_API_KEY=CLOUDFLARE_API_KEY)
+            logger.info(
+                'chosen_dns_provider',
+                message='Using {0} as dns provider.'.format(dns_provider))
+        except KeyError as e:
+            logger.info("ERROR:: Please supply {0} as an environment variable.".
+                        format(str(e)))
+    else:
+        raise ValueError(
+            'The dns provider {0} is not recognised.'.format(dns_provider))
 
     client = Client(
-        domain_name=domains,
-        CLOUDFLARE_DNS_ZONE_ID=CLOUDFLARE_DNS_ZONE_ID,
-        CLOUDFLARE_EMAIL=CLOUDFLARE_EMAIL,
-        CLOUDFLARE_API_KEY=CLOUDFLARE_API_KEY,
-        account_key=account_key)
+        domain_name=domains, dns_class=dns_class, account_key=account_key)
 
     certificate_key = client.certificate_key
     account_key = client.account_key

--- a/sewer/cli.py
+++ b/sewer/cli.py
@@ -101,11 +101,12 @@ def main():
         certificate = client.cert()
 
     # write out certificate, certificate key and account key in current directory
-    with open('certificate.crt', 'w') as certificate_file:
+    with open('{0}.certificate.crt'.format(domains), 'w') as certificate_file:
         certificate_file.write(certificate)
-    with open('certificate.key', 'w') as certificate_key_file:
+    with open('{0}.certificate.key'.format(domains),
+              'w') as certificate_key_file:
         certificate_key_file.write(certificate_key)
-    with open('account.key', 'w') as account_file:
+    with open('{0}.account.key'.format(domains), 'w') as account_file:
         account_file.write(account_key)
 
     logger.info("the_end", message=message)

--- a/sewer/dns_providers/cloudflare.py
+++ b/sewer/dns_providers/cloudflare.py
@@ -1,0 +1,82 @@
+import json
+import urlparse
+
+import requests
+
+from . import common
+
+
+class CloudFlareDns(common.BaseDns):
+    """
+    """
+
+    def __init__(
+            self,
+            CLOUDFLARE_DNS_ZONE_ID,
+            CLOUDFLARE_EMAIL,
+            CLOUDFLARE_API_KEY,
+            CLOUDFLARE_API_BASE_URL='https://api.cloudflare.com/client/v4/'):
+        self.CLOUDFLARE_DNS_ZONE_ID = CLOUDFLARE_DNS_ZONE_ID
+        self.CLOUDFLARE_EMAIL = CLOUDFLARE_EMAIL
+        self.CLOUDFLARE_API_KEY = CLOUDFLARE_API_KEY
+        self.CLOUDFLARE_API_BASE_URL = CLOUDFLARE_API_BASE_URL
+        self.dns_provider_name = 'cloudflare'
+
+        if CLOUDFLARE_API_BASE_URL[-1] != '/':
+            self.CLOUDFLARE_API_BASE_URL = CLOUDFLARE_API_BASE_URL + '/'
+        else:
+            self.CLOUDFLARE_API_BASE_URL = CLOUDFLARE_API_BASE_URL
+
+    def create_dns_record(self, domain_name, base64_of_acme_keyauthorization):
+        url = urlparse.urljoin(
+            self.CLOUDFLARE_API_BASE_URL,
+            'zones/{0}/dns_records'.format(self.CLOUDFLARE_DNS_ZONE_ID))
+        headers = {
+            'X-Auth-Email': self.CLOUDFLARE_EMAIL,
+            'X-Auth-Key': self.CLOUDFLARE_API_KEY,
+            'Content-Type': 'application/json'
+        }
+        body = {
+            "type": "TXT",
+            "name": '_acme-challenge' + '.' + self.domain_name,
+            "content": "{0}".format(base64_of_acme_keyauthorization)
+        }
+        create_cloudflare_dns_record_response = requests.post(
+            url,
+            headers=headers,
+            data=json.dumps(body),
+            timeout=self.ACME_REQUEST_TIMEOUT)
+        return create_cloudflare_dns_record_response
+
+    def delete_dns_record(self, domain_name, base64_of_acme_keyauthorization):
+        headers = {
+            'X-Auth-Email': self.CLOUDFLARE_EMAIL,
+            'X-Auth-Key': self.CLOUDFLARE_API_KEY,
+            'Content-Type': 'application/json'
+        }
+        list_dns_payload = {'type': 'TXT', 'name': domain_name}
+        list_dns_url = urlparse.urljoin(
+            self.CLOUDFLARE_API_BASE_URL,
+            'zones/{0}/dns_records'.format(self.CLOUDFLARE_DNS_ZONE_ID))
+
+        list_dns_response = requests.get(
+            list_dns_url,
+            params=list_dns_payload,
+            headers=headers,
+            timeout=self.ACME_REQUEST_TIMEOUT)
+
+        print "list_dns_response status:", list_dns_response
+        print "\n\n"
+        print "list_dns_response json", list_dns_response.json()
+
+        url = urlparse.urljoin(self.CLOUDFLARE_API_BASE_URL,
+                               'zones/{0}/dns_records/{1}'.format(
+                                   self.CLOUDFLARE_DNS_ZONE_ID, dns_record_id))
+        headers = {
+            'X-Auth-Email': self.CLOUDFLARE_EMAIL,
+            'X-Auth-Key': self.CLOUDFLARE_API_KEY,
+            'Content-Type': 'application/json'
+        }
+        response = requests.delete(
+            url, headers=headers, timeout=self.ACME_REQUEST_TIMEOUT)
+        return response

--- a/sewer/dns_providers/cloudflare.py
+++ b/sewer/dns_providers/cloudflare.py
@@ -16,6 +16,7 @@ class CloudFlareDns(common.BaseDns):
             CLOUDFLARE_EMAIL,
             CLOUDFLARE_API_KEY,
             CLOUDFLARE_API_BASE_URL='https://api.cloudflare.com/client/v4/'):
+
         self.CLOUDFLARE_DNS_ZONE_ID = CLOUDFLARE_DNS_ZONE_ID
         self.CLOUDFLARE_EMAIL = CLOUDFLARE_EMAIL
         self.CLOUDFLARE_API_KEY = CLOUDFLARE_API_KEY
@@ -38,7 +39,7 @@ class CloudFlareDns(common.BaseDns):
         }
         body = {
             "type": "TXT",
-            "name": '_acme-challenge' + '.' + self.domain_name,
+            "name": '_acme-challenge' + '.' + domain_name,
             "content": "{0}".format(base64_of_acme_keyauthorization)
         }
         create_cloudflare_dns_record_response = requests.post(

--- a/sewer/dns_providers/cloudflare.py
+++ b/sewer/dns_providers/cloudflare.py
@@ -56,7 +56,9 @@ class CloudFlareDns(common.BaseDns):
             'X-Auth-Key': self.CLOUDFLARE_API_KEY,
             'Content-Type': 'application/json'
         }
-        list_dns_payload = {'type': 'TXT', 'name': domain_name}
+
+        dns_name = '_acme-challenge' + '.' + domain_name
+        list_dns_payload = {'type': 'TXT', 'name': dns_name}
         list_dns_url = urlparse.urljoin(
             self.CLOUDFLARE_API_BASE_URL,
             'zones/{0}/dns_records'.format(self.CLOUDFLARE_DNS_ZONE_ID))
@@ -67,7 +69,9 @@ class CloudFlareDns(common.BaseDns):
             headers=headers,
             timeout=self.HTTP_TIMEOUT)
 
-        print "list_dns_response status:", list_dns_response
+        dns_record_id = list_dns_response.json()['result'][0]['id']
+
+        print "list_dns_response status: dns_record_id:", list_dns_response, dns_record_id
         print "\n\n"
         print "list_dns_response json", list_dns_response.json()
 

--- a/sewer/dns_providers/cloudflare.py
+++ b/sewer/dns_providers/cloudflare.py
@@ -22,7 +22,7 @@ class CloudFlareDns(common.BaseDns):
         self.CLOUDFLARE_API_KEY = CLOUDFLARE_API_KEY
         self.CLOUDFLARE_API_BASE_URL = CLOUDFLARE_API_BASE_URL
         self.dns_provider_name = 'cloudflare'
-        self.HTTP_TIMEOUT = 65 # seconds
+        self.HTTP_TIMEOUT = 65  # seconds
 
         if CLOUDFLARE_API_BASE_URL[-1] != '/':
             self.CLOUDFLARE_API_BASE_URL = CLOUDFLARE_API_BASE_URL + '/'

--- a/sewer/dns_providers/cloudflare.py
+++ b/sewer/dns_providers/cloudflare.py
@@ -22,6 +22,7 @@ class CloudFlareDns(common.BaseDns):
         self.CLOUDFLARE_API_KEY = CLOUDFLARE_API_KEY
         self.CLOUDFLARE_API_BASE_URL = CLOUDFLARE_API_BASE_URL
         self.dns_provider_name = 'cloudflare'
+        self.HTTP_TIMEOUT = 65 # seconds
 
         if CLOUDFLARE_API_BASE_URL[-1] != '/':
             self.CLOUDFLARE_API_BASE_URL = CLOUDFLARE_API_BASE_URL + '/'
@@ -46,7 +47,7 @@ class CloudFlareDns(common.BaseDns):
             url,
             headers=headers,
             data=json.dumps(body),
-            timeout=self.ACME_REQUEST_TIMEOUT)
+            timeout=self.HTTP_TIMEOUT)
         return create_cloudflare_dns_record_response
 
     def delete_dns_record(self, domain_name, base64_of_acme_keyauthorization):
@@ -64,7 +65,7 @@ class CloudFlareDns(common.BaseDns):
             list_dns_url,
             params=list_dns_payload,
             headers=headers,
-            timeout=self.ACME_REQUEST_TIMEOUT)
+            timeout=self.HTTP_TIMEOUT)
 
         print "list_dns_response status:", list_dns_response
         print "\n\n"
@@ -79,5 +80,5 @@ class CloudFlareDns(common.BaseDns):
             'Content-Type': 'application/json'
         }
         response = requests.delete(
-            url, headers=headers, timeout=self.ACME_REQUEST_TIMEOUT)
+            url, headers=headers, timeout=self.HTTP_TIMEOUT)
         return response

--- a/sewer/dns_providers/cloudflare.py
+++ b/sewer/dns_providers/cloudflare.py
@@ -70,11 +70,6 @@ class CloudFlareDns(common.BaseDns):
             timeout=self.HTTP_TIMEOUT)
 
         dns_record_id = list_dns_response.json()['result'][0]['id']
-
-        print "list_dns_response status: dns_record_id:", list_dns_response, dns_record_id
-        print "\n\n"
-        print "list_dns_response json", list_dns_response.json()
-
         url = urlparse.urljoin(self.CLOUDFLARE_API_BASE_URL,
                                'zones/{0}/dns_records/{1}'.format(
                                    self.CLOUDFLARE_DNS_ZONE_ID, dns_record_id))

--- a/sewer/dns_providers/common.py
+++ b/sewer/dns_providers/common.py
@@ -1,0 +1,25 @@
+from structlog import get_logger
+
+
+class BaseDns(object):
+    """
+    """
+
+    def __init__(self):
+        self.dns_provider_name = None
+        if self.dns_provider_name is None:
+            raise ValueError(
+                'The class attribute dns_provider_name ought to be defined.')
+
+        self.logger = get_logger(__name__).bind(
+            dns_provider_name=self.dns_provider_name)
+
+    def create_dns_record(self, domain_name, base64_of_acme_keyauthorization):
+        self.logger.info('create_dns_record')
+        raise NotImplementedError(
+            'create_dns_record method must be implemented.')
+
+    def delete_dns_record(self, domain_name, dns_record_id):
+        self.logger.info('delete_dns_record')
+        raise NotImplementedError(
+            'delete_dns_record method must be implemented.')


### PR DESCRIPTION
Thank you for contributing to sewer.                    
Every contribution to sewer is important to us.                       
You may not know it, but you have just contributed to making the world a more safer and secure place.                         

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to sewer, and sewer agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that sewer shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

## What(What have you changed?)
- make the acme client to be dns provider agnostic


## Why(Why did you change it?)
- to be able to easliy support more dns providers in future

