### PR TITLE
Specify bundlename

### DIFF
--- a/sewer/__version__.py
+++ b/sewer/__version__.py
@@ -1,7 +1,7 @@
 __title__ = "sewer"
 __description__ = "Sewer is a programmatic Lets Encrypt(ACME) client"
 __url__ = "https://github.com/komuW/sewer"
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 __author__ = "komuW"
 __author_email__ = "komuw05@gmail.com"
 __license__ = "MIT"

--- a/sewer/cli.py
+++ b/sewer/cli.py
@@ -50,6 +50,12 @@ def main():
         help="The domain/subdomain name for which \
         you want to get/renew certificate for.")
     parser.add_argument(
+        "--bundle_name",
+        type=str,
+        required=False,
+        help="The name to use for certificate \
+        certificate key and account key. Default is value of domains.")
+    parser.add_argument(
         "--action",
         type=str,
         required=True,
@@ -64,6 +70,7 @@ def main():
     domains = args.domains
     action = args.action
     account_key = args.account_key
+    bundle_name = args.bundle_name
     if account_key:
         account_key = account_key.read()
 
@@ -100,13 +107,18 @@ def main():
         message = 'Certificate Succesfully issued. The certificate, certificate key and account key have been saved in the current directory'
         certificate = client.cert()
 
+    if bundle_name:
+        file_name = bundle_name
+    else:
+        file_name = '{0}'.format(domains)
+
     # write out certificate, certificate key and account key in current directory
-    with open('{0}.certificate.crt'.format(domains), 'w') as certificate_file:
+    with open('{0}.certificate.crt'.format(file_name), 'w') as certificate_file:
         certificate_file.write(certificate)
-    with open('{0}.certificate.key'.format(domains),
+    with open('{0}.certificate.key'.format(file_name),
               'w') as certificate_key_file:
         certificate_key_file.write(certificate_key)
-    with open('{0}.account.key'.format(domains), 'w') as account_file:
+    with open('{0}.account.key'.format(file_name), 'w') as account_file:
         account_file.write(account_key)
 
     logger.info("the_end", message=message)


### PR DESCRIPTION
Thank you for contributing to sewer.                    
Every contribution to sewer is important to us.                       
You may not know it, but you have just contributed to making the world a more safer and secure place.                         

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to sewer, and sewer agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that sewer shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

## What(What have you changed?)
- add ability to specify bundle name


## Why(Why did you change it?)
- you may be using a webserver that needs static certificate credential names

