### PR TITLE
use provide bundle_name as is in certificate and certificate key names

### DIFF
--- a/sewer/__version__.py
+++ b/sewer/__version__.py
@@ -1,7 +1,7 @@
 __title__ = "sewer"
 __description__ = "Sewer is a programmatic Lets Encrypt(ACME) client"
 __url__ = "https://github.com/komuW/sewer"
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 __author__ = "komuW"
 __author_email__ = "komuw05@gmail.com"
 __license__ = "MIT"

--- a/sewer/cli.py
+++ b/sewer/cli.py
@@ -113,10 +113,9 @@ def main():
         file_name = '{0}'.format(domains)
 
     # write out certificate, certificate key and account key in current directory
-    with open('{0}.certificate.crt'.format(file_name), 'w') as certificate_file:
+    with open('{0}.crt'.format(file_name), 'w') as certificate_file:
         certificate_file.write(certificate)
-    with open('{0}.certificate.key'.format(file_name),
-              'w') as certificate_key_file:
+    with open('{0}.key'.format(file_name), 'w') as certificate_key_file:
         certificate_key_file.write(certificate_key)
     with open('{0}.account.key'.format(file_name), 'w') as account_file:
         account_file.write(account_key)


### PR DESCRIPTION
Thank you for contributing to sewer.                    
Every contribution to sewer is important to us.                       
You may not know it, but you have just contributed to making the world a more safer and secure place.                         

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to sewer, and sewer agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that sewer shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

## What(What have you changed?)
- use specified bundle_name in certificate and certificate key names.

## Why(Why did you change it?)
- use user supplied name

