### PR TITLE
fix cert naming typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ certificate = client.cert()
 certificate_key = client.certificate_key
 account_key = client.account_key
 
-print "your certicate is:", certificate
+print "your certificate is:", certificate
 print "your certificate's key is:", certificate_key
 print "\n\n"
 print "you can write them to a file then add that file to your favourite webserver."
@@ -160,7 +160,7 @@ The commandline interface(app) is called `sewer` or alternatively you could use,
 - open an issue on this repo. In your issue, outline what it is you want to add and why.
 - install pre-requiste software:             
 ```shell
-apt-get install pandoc && pip install twine wheel pypandoc coverage yapf flake8
+apt-get install pandoc && pip install twine wheel pypandoc coverage yapf flake8 mock
 ```                   
 - make the changes you want on your fork.
 - your changes should have backward compatibility in mind unless it is impossible to do so.
@@ -175,6 +175,10 @@ yapf --in-place --style "google" -r .
 ```shell
 flake8 .
 ```                      
+- run tests and make sure everything is passing:
+```shell
+make tests
+```
 - open a pull request on this repo.               
 NB: I make no commitment of accepting your pull requests.                 
 
@@ -212,7 +216,7 @@ sewer \
 2017-07-14 18:10.08 get_acme_header                ACME_CERTIFICATE_AUTHORITY_URL=https://acme-staging.api.letsencrypt.org client_name=ACMEclient domain_name=subdomain.example.com
 2017-07-14 18:10.10 sign_message                   ACME_CERTIFICATE_AUTHORITY_URL=https://acme-staging.api.letsencrypt.org client_name=ACMEclient domain_name=subdomain.example.com
 2017-07-14 18:10.11 check_challenge                ACME_CERTIFICATE_AUTHORITY_URL=https://acme-staging.api.letsencrypt.org client_name=ACMEclient domain_name=subdomain.example.com
-2017-07-14 18:10.19 get_certicate                  ACME_CERTIFICATE_AUTHORITY_URL=https://acme-staging.api.letsencrypt.org client_name=ACMEclient domain_name=subdomain.example.com
+2017-07-14 18:10.19 get_certificate                  ACME_CERTIFICATE_AUTHORITY_URL=https://acme-staging.api.letsencrypt.org client_name=ACMEclient domain_name=subdomain.example.com
 2017-07-14 18:10.19 make_signed_acme_request       ACME_CERTIFICATE_AUTHORITY_URL=https://acme-staging.api.letsencrypt.org client_name=ACMEclient domain_name=subdomain.example.com
 2017-07-14 18:10.19 get_acme_header                ACME_CERTIFICATE_AUTHORITY_URL=https://acme-staging.api.letsencrypt.org client_name=ACMEclient domain_name=subdomain.example.com
 2017-07-14 18:10.21 sign_message                   ACME_CERTIFICATE_AUTHORITY_URL=https://acme-staging.api.letsencrypt.org client_name=ACMEclient domain_name=subdomain.example.com

--- a/sewer/ACMEclient.py
+++ b/sewer/ACMEclient.py
@@ -364,21 +364,21 @@ class ACMEclient(object):
                 break
         return check_challenge_status_response
 
-    def get_certicate(self):
-        self.logger.info('get_certicate')
+    def get_certificate(self):
+        self.logger.info('get_certificate')
         payload = {
             "resource": "new-cert",
             "csr": self.calculate_safe_base64(self.csr)
         }
         url = urlparse.urljoin(self.ACME_CERTIFICATE_AUTHORITY_URL,
                                '/acme/new-cert')
-        get_certicate_response = self.make_signed_acme_request(url, payload)
+        get_certificate_response = self.make_signed_acme_request(url, payload)
         self.logger.info(
-            'get_certicate_response',
-            status_code=get_certicate_response.status_code,
-            response=self.log_response(get_certicate_response))
+            'get_certificate_response',
+            status_code=get_certificate_response.status_code,
+            response=self.log_response(get_certificate_response))
         base64encoded_cert = base64.b64encode(
-            get_certicate_response.content).decode('utf8')
+            get_certificate_response.content).decode('utf8')
         sixty_four_width_cert = textwrap.wrap(base64encoded_cert, 64)
         certificate = '\n'.join(sixty_four_width_cert)
 
@@ -399,7 +399,7 @@ class ACMEclient(object):
         self.notify_acme_challenge_set(acme_keyauthorization, dns_challenge_url)
         self.check_challenge_status(dns_challenge_url,
                                     base64_of_acme_keyauthorization)
-        certificate = self.get_certicate()
+        certificate = self.get_certificate()
 
         return certificate
 

--- a/sewer/tests/test_ACMEclient.py
+++ b/sewer/tests/test_ACMEclient.py
@@ -208,10 +208,10 @@ class TestACMEclient(TestCase):
             self.client.cert()
             self.assertTrue(mock_delete_dns_record.called)
 
-    def test_get_certicate_is_called(self):
+    def test_get_certificate_is_called(self):
         with mock.patch('requests.post') as mock_requests_post, mock.patch(
                 'requests.get') as mock_requests_get, mock.patch(
-                    'sewer.Client.get_certicate') as mock_get_certicate:
+                    'sewer.Client.get_certificate') as mock_get_certificate:
             content = """
                           {"challenges": [{"type": "dns-01", "token": "example-token", "uri": "example-uri"}]}
                       """
@@ -220,9 +220,9 @@ class TestACMEclient(TestCase):
             mock_requests_get.return_value = test_utils.MockResponse(
                 content=content)
             self.client.cert()
-            self.assertTrue(mock_get_certicate.called)
+            self.assertTrue(mock_get_certificate.called)
 
-    def test_certicate_is_issued(self):
+    def test_certificate_is_issued(self):
         with mock.patch('requests.post') as mock_requests_post, mock.patch(
                 'requests.get') as mock_requests_get:
             content = """


### PR DESCRIPTION
Thank you for contributing to sewer.                    
Every contribution to sewer is important to us.                       
You may not know it, but you have just contributed to making the world a more safer and secure place.                         

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to sewer, and sewer agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that sewer shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

## What(What have you changed?)
- rename certicate to certificate

## Why(Why did you change it?)
- use proper english names
- fix https://github.com/komuW/sewer/issues/44

