### PR TITLE
only get certificates if no errors

### DIFF
--- a/sewer/ACMEclient.py
+++ b/sewer/ACMEclient.py
@@ -270,6 +270,14 @@ class ACMEclient(object):
             'acme_register_response',
             status_code=acme_register_response.status_code,
             response=self.log_response(acme_register_response))
+
+        if acme_register_response.status_code not in [201, 409]:
+            raise ValueError(
+                "Error while registering: status_code={status_code} response={response}".
+                format(
+                    status_code=acme_register_response.status_code,
+                    response=self.log_response(acme_register_response)))
+
         return acme_register_response
 
     def get_challenge(self):

--- a/sewer/ACMEclient.py
+++ b/sewer/ACMEclient.py
@@ -377,6 +377,14 @@ class ACMEclient(object):
             'get_certificate_response',
             status_code=get_certificate_response.status_code,
             response=self.log_response(get_certificate_response))
+
+        if get_certificate_response.status_code != 201:
+            raise ValueError(
+                "Error fetching certificate: status_code={status_code} response={response}".
+                format(
+                    status_code=get_certificate_response.status_code,
+                    response=self.log_response(get_certificate_response)))
+
         base64encoded_cert = base64.b64encode(
             get_certificate_response.content).decode('utf8')
         sixty_four_width_cert = textwrap.wrap(base64encoded_cert, 64)

--- a/sewer/ACMEclient.py
+++ b/sewer/ACMEclient.py
@@ -173,6 +173,20 @@ class ACMEclient(object):
         self.logger.info(
             'get_certificate_chain_response',
             status_code=get_certificate_chain_response.status_code)
+
+        if get_certificate_chain_response.status_code not in [200, 201]:
+            raise ValueError(
+                "Error while getting Acme certificate chain: status_code={status_code} response={response}".
+                format(
+                    status_code=get_certificate_chain_response.status_code,
+                    response=self.log_response(get_certificate_chain_response)))
+        elif '-----BEGIN CERTIFICATE-----' and '-----END CERTIFICATE-----' not in get_certificate_chain_response.content:
+            raise ValueError(
+                "Error while getting Acme certificate chain: status_code={status_code} response={response}".
+                format(
+                    status_code=get_certificate_chain_response.status_code,
+                    response=self.log_response(get_certificate_chain_response)))
+
         return certificate_chain
 
     def calculate_safe_base64(self, un_encoded_data):

--- a/sewer/ACMEclient.py
+++ b/sewer/ACMEclient.py
@@ -290,6 +290,13 @@ class ACMEclient(object):
             status_code=challenge_response.status_code,
             response=self.log_response(challenge_response))
 
+        if challenge_response.status_code != 201:
+            raise ValueError(
+                "Error requesting for challenges: status_code={status_code} response={response}".
+                format(
+                    status_code=challenge_response.status_code,
+                    response=self.log_response(challenge_response)))
+
         for i in challenge_response.json()['challenges']:
             if i['type'] == 'dns-01':
                 dns_challenge = i

--- a/sewer/ACMEclient.py
+++ b/sewer/ACMEclient.py
@@ -380,7 +380,7 @@ class ACMEclient(object):
 
         if get_certificate_response.status_code != 201:
             raise ValueError(
-                "Error fetching certificate: status_code={status_code} response={response}".
+                "Error fetching signed certificate: status_code={status_code} response={response}".
                 format(
                     status_code=get_certificate_response.status_code,
                     response=self.log_response(get_certificate_response)))

--- a/sewer/tests/test_ACMEclient.py
+++ b/sewer/tests/test_ACMEclient.py
@@ -241,11 +241,34 @@ class TestACMEclient(TestCase):
             ]:
                 self.assertIn(i, self.client.cert())
 
+    def test_certificate_is_not_issued(self):
+        with mock.patch('requests.post') as mock_requests_post, mock.patch(
+                'requests.get') as mock_requests_get:
+            content = """
+                          {"challenges": [{"type": "dns-01", "token": "example-token", "uri": "example-uri"}]}
+                      """
+            mock_requests_post.return_value = test_utils.MockResponse(
+                status_code=400, content=content)
+            mock_requests_get.return_value = test_utils.MockResponse(
+                status_code=400, content=content)
 
-# TEST cli
-# from unittest import TestCase
-# from funniest.command_line import main
+            def mock_get_certificate():
+                self.client.cert()
 
-# class TestConsole(TestCase):
-#     def test_basic(self):
-#         main()
+            self.assertRaises(ValueError, mock_get_certificate)
+
+            with self.assertRaises(ValueError) as raised_exception:
+                mock_get_certificate()
+            self.assertIn('Error fetching signed certificate',
+                          raised_exception.exception.message)
+
+            # certificate = self.client.cert()
+            # self.assertIn('-----BEGIN CERTIFICATE-----', certificate)
+
+        # TEST cli
+        # from unittest import TestCase
+        # from funniest.command_line import main
+
+        # class TestConsole(TestCase):
+        #     def test_basic(self):
+        #         main()

--- a/sewer/tests/test_ACMEclient.py
+++ b/sewer/tests/test_ACMEclient.py
@@ -43,6 +43,27 @@ class TestACMEclient(TestCase):
     def tearDown(self):
         pass
 
+    def test_get_certificate_chain_failure_results_in_exception(self):
+        with mock.patch('requests.post') as mock_requests_post, mock.patch(
+                'requests.get') as mock_requests_get:
+            mock_requests_post.return_value = test_utils.MockResponse(
+                status_code=409)
+            mock_requests_get.return_value = test_utils.MockResponse(
+                status_code=409)
+
+            def mock_create_acme_client():
+                sewer.Client(
+                    domain_name='example.com',
+                    dns_class=test_utils.ExmpleDnsProvider(),
+                    ACME_CERTIFICATE_AUTHORITY_URL=
+                    "https://acme-staging.api.letsencrypt.org")
+
+            self.assertRaises(ValueError, mock_create_acme_client)
+            with self.assertRaises(ValueError) as raised_exception:
+                mock_create_acme_client()
+            self.assertIn('Error while getting Acme certificate chain',
+                          raised_exception.exception.message)
+
     def test_user_agent_is_generated(self):
         with mock.patch('requests.post') as mock_requests_post, mock.patch(
                 'requests.get') as mock_requests_get:

--- a/sewer/tests/test_utils.py
+++ b/sewer/tests/test_utils.py
@@ -20,7 +20,7 @@ class MockResponse(object):
     mock python-requests Response object
     """
 
-    def __init__(self, status_code=200, content='{"something": "ok"}'):
+    def __init__(self, status_code=201, content='{"something": "ok"}'):
         self.status_code = status_code
         self.content = content
         self.headers = {'Replay-Nonce': 'example-replay-Nonce'}

--- a/sewer/tests/test_utils.py
+++ b/sewer/tests/test_utils.py
@@ -22,8 +22,9 @@ class MockResponse(object):
 
     def __init__(self, status_code=201, content='{"something": "ok"}'):
         self.status_code = status_code
-        self.content = content
+        self.content = content + '-----BEGIN CERTIFICATE----- some-mock-certificate -----END CERTIFICATE-----'
+        self.content_to_use_in_json_method = content
         self.headers = {'Replay-Nonce': 'example-replay-Nonce'}
 
     def json(self):
-        return json.loads(self.content)
+        return json.loads(self.content_to_use_in_json_method)

--- a/sewer/tests/test_utils.py
+++ b/sewer/tests/test_utils.py
@@ -22,6 +22,7 @@ class MockResponse(object):
 
     def __init__(self, status_code=201, content='{"something": "ok"}'):
         self.status_code = status_code
+        # the certificate tags are needed by the `get_certificate_chain` method of AcmeClient
         self.content = content + '-----BEGIN CERTIFICATE----- some-mock-certificate -----END CERTIFICATE-----'
         self.content_to_use_in_json_method = content
         self.headers = {'Replay-Nonce': 'example-replay-Nonce'}


### PR DESCRIPTION
Thank you for contributing to sewer.                    
Every contribution to sewer is important to us.                       
You may not know it, but you have just contributed to making the world a more safer and secure place.                         

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to sewer, and sewer agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that sewer shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

## What(What have you changed?)
- only get certificates if certificate is valid.

## Why(Why did you change it?)
- fixes: https://github.com/komuW/sewer/issues/48
- fixes: https://github.com/komuW/sewer/issues/43
