### PR TITLE
bugfix: cli unable to acquire certificates.

### DIFF
--- a/sewer/__version__.py
+++ b/sewer/__version__.py
@@ -1,7 +1,7 @@
 __title__ = "sewer"
 __description__ = "Sewer is a programmatic Lets Encrypt(ACME) client"
 __url__ = "https://github.com/komuW/sewer"
-__version__ = "0.2.6"
+__version__ = "0.2.7"
 __author__ = "komuW"
 __author_email__ = "komuw05@gmail.com"
 __license__ = "MIT"

--- a/sewer/cli.py
+++ b/sewer/cli.py
@@ -47,7 +47,7 @@ def main():
         "--dns",
         type=str,
         required=True,
-        choices=['cloudflare, aurora'],
+        choices=['cloudflare', 'aurora'],
         help="The name of the dns provider that you want to use.")
     parser.add_argument(
         "--domains",


### PR DESCRIPTION
Thank you for contributing to sewer.                    
Every contribution to sewer is important to us.                       
You may not know it, but you have just contributed to making the world a more safer and secure place.                         

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to sewer, and sewer agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that sewer shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

## What(What have you changed?)
- made parser add arguments' choices field to be a list

## Why(Why did you change it?)
- fix: https://github.com/komuW/sewer/issues/53
