### PR TITLE
*.py: rename base64_of_acme_keyauthorization gave it a proper meaning…

### DIFF
--- a/sewer/client.py
+++ b/sewer/client.py
@@ -390,8 +390,7 @@ class Client(object):
 
     def check_authorization_status(
             self,
-            authorization_url,
-            base64_of_acme_keyauthorization):
+            authorization_url):
         """
         https://tools.ietf.org/html/draft-ietf-acme-acme-09#section-7.5.1
         To check on the status of an authorization, the client sends a GET(polling)
@@ -629,7 +628,7 @@ class Client(object):
 
     def get_certificate(self):
         self.logger.debug('get_certificate')
-        base64_of_acme_keyauthorization = "placeholder"
+        domain_dns_value = "placeholder"
         dns_names_to_delete = []
         try:
             self.acme_register()
@@ -640,12 +639,10 @@ class Client(object):
                 dns_names_to_delete.append(dns_name)
                 dns_token, dns_challenge_url = self.get_challenge(
                     url=authorization_url)
-                acme_keyauthorization, base64_of_acme_keyauthorization = self.get_keyauthorization(
+                acme_keyauthorization, domain_dns_value = self.get_keyauthorization(
                     dns_token)
-                self.dns_class.create_dns_record(
-                    dns_name, base64_of_acme_keyauthorization)
-                self.check_authorization_status(
-                    authorization_url, base64_of_acme_keyauthorization)
+                self.dns_class.create_dns_record(dns_name, domain_dns_value)
+                self.check_authorization_status(authorization_url)
                 self.respond_to_challenge(
                     acme_keyauthorization, dns_challenge_url)
             certificate_url = self.send_csr(finalize_url)
@@ -656,8 +653,7 @@ class Client(object):
             raise e
         finally:
             for dns_name in dns_names_to_delete:
-                self.dns_class.delete_dns_record(
-                    dns_name, base64_of_acme_keyauthorization)
+                self.dns_class.delete_dns_record(dns_name, domain_dns_value)
 
         return certificate
 

--- a/sewer/dns_providers/auroradns.py
+++ b/sewer/dns_providers/auroradns.py
@@ -22,7 +22,7 @@ class AuroraDns(common.BaseDns):
         self.AURORA_SECRET_KEY = AURORA_SECRET_KEY
         super(AuroraDns, self).__init__()
 
-    def create_dns_record(self, domain_name, base64_of_acme_keyauthorization):
+    def create_dns_record(self, domain_name, domain_dns_value):
         self.logger.info('create_dns_record')
         # if we have been given a wildcard name, strip wildcard
         domain_name = domain_name.lstrip('*.')
@@ -30,7 +30,7 @@ class AuroraDns(common.BaseDns):
         # delete any prior existing DNS authorizations that may exist already
         self.delete_dns_record(
             domain_name=domain_name,
-            base64_of_acme_keyauthorization=base64_of_acme_keyauthorization)
+            domain_dns_value=domain_dns_value)
 
         extractedDomain = tldextract.extract(domain_name)
         domainSuffix = extractedDomain.domain + '.' + extractedDomain.suffix
@@ -46,12 +46,12 @@ class AuroraDns(common.BaseDns):
         zone.create_record(
             name=subDomain,
             type=RecordType.TXT,
-            data=base64_of_acme_keyauthorization)
+            data=domain_dns_value)
 
         self.logger.info('create_dns_record_success')
         return
 
-    def delete_dns_record(self, domain_name, base64_of_acme_keyauthorization):
+    def delete_dns_record(self, domain_name, domain_dns_value):
         self.logger.info('delete_dns_record')
 
         extractedDomain = tldextract.extract(domain_name)

--- a/sewer/dns_providers/cloudflare.py
+++ b/sewer/dns_providers/cloudflare.py
@@ -62,7 +62,7 @@ class CloudFlareDns(common.BaseDns):
 
         self.logger.debug('find_dns_zone_success')
 
-    def create_dns_record(self, domain_name, base64_of_acme_keyauthorization):
+    def create_dns_record(self, domain_name, domain_dns_value):
         self.logger.info('create_dns_record')
         # if we have been given a wildcard name, strip wildcard
         domain_name = domain_name.lstrip('*.')
@@ -71,7 +71,7 @@ class CloudFlareDns(common.BaseDns):
         # delete any prior existing DNS authorizations that may exist already
         self.delete_dns_record(
             domain_name=domain_name,
-            base64_of_acme_keyauthorization=base64_of_acme_keyauthorization)
+            domain_dns_value=domain_dns_value)
         url = urllib.parse.urljoin(self.CLOUDFLARE_API_BASE_URL,
                                    'zones/{0}/dns_records'.format(
                                        self.CLOUDFLARE_DNS_ZONE_ID))
@@ -83,7 +83,7 @@ class CloudFlareDns(common.BaseDns):
         body = {
             "type": "TXT",
             "name": '_acme-challenge' + '.' + domain_name + '.',
-            "content": "{0}".format(base64_of_acme_keyauthorization)
+            "content": "{0}".format(domain_dns_value)
         }
         create_cloudflare_dns_record_response = requests.post(
             url,
@@ -102,7 +102,7 @@ class CloudFlareDns(common.BaseDns):
                     response=self.log_response(create_cloudflare_dns_record_response)))
         self.logger.info('create_dns_record_end')
 
-    def delete_dns_record(self, domain_name, base64_of_acme_keyauthorization):
+    def delete_dns_record(self, domain_name, domain_dns_value):
         self.logger.info('delete_dns_record')
 
         class MockResponse(object):

--- a/sewer/dns_providers/common.py
+++ b/sewer/dns_providers/common.py
@@ -26,21 +26,21 @@ class BaseDns(object):
             log_body = response.content
         return log_body
 
-    def create_dns_record(self, domain_name, base64_of_acme_keyauthorization):
+    def create_dns_record(self, domain_name, domain_dns_value):
         """
         Method that creates/adds a dns TXT record for a domain/subdomain name on
         a chosen DNS provider.
 
         :param domain_name: :string: The domain/subdomain name whose dns record ought to be
             created/added on a chosen DNS provider.
-        :param base64_of_acme_keyauthorization: :string: The value/content of the TXT record that will be
+        :param domain_dns_value: :string: The value/content of the TXT record that will be
             created/added for the given domain/subdomain
 
         This method should return None
 
         Basic Usage:
             If the value of the `domain_name` variable is example.com and the value of
-            `base64_of_acme_keyauthorization` is HAJA_4MkowIFByHhFaP8u035skaM91lTKplKld
+            `domain_dns_value` is HAJA_4MkowIFByHhFaP8u035skaM91lTKplKld
             Then, your implementation of this method ought to create a DNS TXT record
             whose name is '_acme-challenge' + '.' + domain_name + '.' (ie: _acme-challenge.example.com. )
             and whose value/content is HAJA_4MkowIFByHhFaP8u035skaM91lTKplKld
@@ -61,14 +61,14 @@ class BaseDns(object):
         raise NotImplementedError(
             'create_dns_record method must be implemented.')
 
-    def delete_dns_record(self, domain_name, base64_of_acme_keyauthorization):
+    def delete_dns_record(self, domain_name, domain_dns_value):
         """
         Method that deletes/removes a dns TXT record for a domain/subdomain name on
         a chosen DNS provider.
 
         :param domain_name: :string: The domain/subdomain name whose dns record ought to be
             deleted/removed on a chosen DNS provider.
-        :param base64_of_acme_keyauthorization: :string: The value/content of the TXT record that will be
+        :param domain_dns_value: :string: The value/content of the TXT record that will be
             deleted/removed for the given domain/subdomain
 
         This method should return None

--- a/sewer/dns_providers/tests/test_aurora.py
+++ b/sewer/dns_providers/tests/test_aurora.py
@@ -16,7 +16,7 @@ class TestAurora(TestCase):
 
     def setUp(self):
         self.domain_name = 'example.com'
-        self.base64_of_acme_keyauthorization = 'mock-base64_of_acme_keyauthorization'
+        self.domain_dns_value = 'mock-domain_dns_value'
         self.AURORA_API_KEY = 'mock-aurora-api-key'
         self.AURORA_SECRET_KEY = 'mock-aurora-secret-key'
 
@@ -48,11 +48,11 @@ class TestAurora(TestCase):
 
             self.dns_class.create_dns_record(
                 domain_name=self.domain_name,
-                base64_of_acme_keyauthorization=self.
-                base64_of_acme_keyauthorization)
+                domain_dns_value=self.
+                domain_dns_value)
             mock_delete_dns_record.assert_called_once_with(
-                base64_of_acme_keyauthorization=self.
-                base64_of_acme_keyauthorization,
+                domain_dns_value=self.
+                domain_dns_value,
                 domain_name=self.domain_name)
 
     def test_aurora_is_called_by_delete_dns_record(self):
@@ -69,5 +69,5 @@ class TestAurora(TestCase):
 
             self.dns_class.delete_dns_record(
                 domain_name=self.domain_name,
-                base64_of_acme_keyauthorization=self.
-                base64_of_acme_keyauthorization)
+                domain_dns_value=self.
+                domain_dns_value)

--- a/sewer/dns_providers/tests/test_cloudflare.py
+++ b/sewer/dns_providers/tests/test_cloudflare.py
@@ -13,7 +13,7 @@ class TestCloudflare(TestCase):
 
     def setUp(self):
         self.domain_name = 'example.com'
-        self.base64_of_acme_keyauthorization = 'mock-base64_of_acme_keyauthorization'
+        self.domain_dns_value = 'mock-domain_dns_value'
         self.CLOUDFLARE_EMAIL = 'mock-email@example.com'
         self.CLOUDFLARE_API_KEY = 'mock-api-key'
         self.CLOUDFLARE_API_BASE_URL = 'https://some-mock-url.com'
@@ -43,11 +43,11 @@ class TestCloudflare(TestCase):
 
             self.dns_class.create_dns_record(
                 domain_name=self.domain_name,
-                base64_of_acme_keyauthorization=self.
-                base64_of_acme_keyauthorization)
+                domain_dns_value=self.
+                domain_dns_value)
             mock_delete_dns_record.assert_called_once_with(
-                base64_of_acme_keyauthorization=self.
-                base64_of_acme_keyauthorization,
+                domain_dns_value=self.
+                domain_dns_value,
                 domain_name=self.domain_name)
 
     def test_cloudflare_is_called_by_create_dns_record(self):
@@ -63,14 +63,14 @@ class TestCloudflare(TestCase):
 
             self.dns_class.create_dns_record(
                 domain_name=self.domain_name,
-                base64_of_acme_keyauthorization=self.
-                base64_of_acme_keyauthorization)
+                domain_dns_value=self.
+                domain_dns_value)
             expected = {
                 'headers': {
                     'X-Auth-Email': self.CLOUDFLARE_EMAIL,
                     'X-Auth-Key': self.CLOUDFLARE_API_KEY,
                     'Content-Type': 'application/json'},
-                'data': '{"content": "mock-base64_of_acme_keyauthorization", "type": "TXT", "name": "_acme-challenge.example.com."}',
+                'data': '{"content": "mock-domain_dns_value", "type": "TXT", "name": "_acme-challenge.example.com."}',
                 'timeout': 65}
 
             self.assertDictEqual(
@@ -92,8 +92,8 @@ class TestCloudflare(TestCase):
 
             self.dns_class.delete_dns_record(
                 domain_name=self.domain_name,
-                base64_of_acme_keyauthorization=self.
-                base64_of_acme_keyauthorization)
+                domain_dns_value=self.
+                domain_dns_value)
             self.assertTrue(mock_requests_get.called)
             expected = {
                 'headers': {

--- a/sewer/dns_providers/tests/test_common.py
+++ b/sewer/dns_providers/tests/test_common.py
@@ -9,7 +9,7 @@ class TestCommon(TestCase):
 
     def setUp(self):
         self.domain_name = 'example.com'
-        self.base64_of_acme_keyauthorization = 'wwfw2402if'
+        self.domain_dns_value = 'wwfw2402if'
         self.dns_class = sewer.BaseDns()
 
     def tearDown(self):
@@ -19,12 +19,12 @@ class TestCommon(TestCase):
         def mock_create_dns_record():
             self.dns_class.create_dns_record(
                 domain_name=self.domain_name,
-                base64_of_acme_keyauthorization=self.base64_of_acme_keyauthorization)
+                domain_dns_value=self.domain_dns_value)
         self.assertRaises(NotImplementedError, mock_create_dns_record)
 
     def test_delete_dns_record(self):
         def mock_delete_dns_record():
             self.dns_class.delete_dns_record(
                 domain_name=self.domain_name,
-                base64_of_acme_keyauthorization=self.base64_of_acme_keyauthorization)
+                domain_dns_value=self.domain_dns_value)
         self.assertRaises(NotImplementedError, mock_delete_dns_record)

--- a/sewer/tests/test_utils.py
+++ b/sewer/tests/test_utils.py
@@ -8,10 +8,10 @@ class ExmpleDnsProvider(sewer.dns_providers.common.BaseDns):
     def __init__(self):
         self.dns_provider_name = 'example_dns_provider'
 
-    def create_dns_record(self, domain_name, base64_of_acme_keyauthorization):
+    def create_dns_record(self, domain_name, domain_dns_value):
         pass
 
-    def delete_dns_record(self, domain_name, base64_of_acme_keyauthorization):
+    def delete_dns_record(self, domain_name, domain_dns_value):
         pass
 
 


### PR DESCRIPTION
…ful name

Thank you for contributing to sewer.                    
Every contribution to sewer is important to us.                       
You may not know it, but you have just contributed to making the world a more safer and secure place.                         

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to sewer, and sewer agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that sewer shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

## What(What have you changed?)
- rename base64_of_acme_keyauthorization

## Why(Why did you change it?)
-  gave it a proper meaningful name
