### PR TITLE
CloudFlareDns: requests have built-in support for json

### DIFF
--- a/sewer/dns_providers/cloudflare.py
+++ b/sewer/dns_providers/cloudflare.py
@@ -81,7 +81,7 @@ class CloudFlareDns(common.BaseDns):
         create_cloudflare_dns_record_response = requests.post(
             url,
             headers=headers,
-            data=body,
+            json=body,
             timeout=self.HTTP_TIMEOUT)
         self.logger.debug(
             'create_cloudflare_dns_record_response. status_code={0}. response={1}'.format(

--- a/sewer/dns_providers/cloudflare.py
+++ b/sewer/dns_providers/cloudflare.py
@@ -1,4 +1,3 @@
-import json
 import urllib.parse
 
 import requests
@@ -36,7 +35,6 @@ class CloudFlareDns(common.BaseDns):
         headers = {
             'X-Auth-Email': self.CLOUDFLARE_EMAIL,
             'X-Auth-Key': self.CLOUDFLARE_API_KEY,
-            'Content-Type': 'application/json'
         }
         find_dns_zone_response = requests.get(
             url, headers=headers, timeout=self.HTTP_TIMEOUT)
@@ -74,7 +72,6 @@ class CloudFlareDns(common.BaseDns):
         headers = {
             'X-Auth-Email': self.CLOUDFLARE_EMAIL,
             'X-Auth-Key': self.CLOUDFLARE_API_KEY,
-            'Content-Type': 'application/json'
         }
         body = {
             "type": "TXT",
@@ -84,7 +81,7 @@ class CloudFlareDns(common.BaseDns):
         create_cloudflare_dns_record_response = requests.post(
             url,
             headers=headers,
-            data=json.dumps(body),
+            data=body,
             timeout=self.HTTP_TIMEOUT)
         self.logger.debug(
             'create_cloudflare_dns_record_response. status_code={0}. response={1}'.format(
@@ -116,7 +113,6 @@ class CloudFlareDns(common.BaseDns):
         headers = {
             'X-Auth-Email': self.CLOUDFLARE_EMAIL,
             'X-Auth-Key': self.CLOUDFLARE_API_KEY,
-            'Content-Type': 'application/json'
         }
 
         dns_name = '_acme-challenge' + '.' + domain_name
@@ -140,7 +136,6 @@ class CloudFlareDns(common.BaseDns):
             headers = {
                 'X-Auth-Email': self.CLOUDFLARE_EMAIL,
                 'X-Auth-Key': self.CLOUDFLARE_API_KEY,
-                'Content-Type': 'application/json'
             }
             delete_dns_record_response = requests.delete(
                 url, headers=headers, timeout=self.HTTP_TIMEOUT)


### PR DESCRIPTION
Explicit JSON serialization can be performed by `requests` since https://github.com/requests/requests/commit/8f17741 (July 2014), thus pushing such functionality leads to cleaner code. I also removed (presumably) copy-pasted `Content-Type` headers from requests without any body at all (`GET` and `DELETE`).