### PR TITLE
Support acme-dns

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - run:
           name: install dependencies
           command: |
-           sudo pip3 install twine wheel pypandoc coverage autopep8 pylint flake8 sewer mock tldextract apache-libcloud
+           sudo pip3 install twine wheel pypandoc coverage autopep8 pylint flake8 sewer mock tldextract apache-libcloud dnspython
 
       # run tests!
       - run:

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ To see help:
 sewer --help                 
         
 usage: sewer [-h] [--version] [--account_key ACCOUNT_KEY] --dns
-             {cloudflare,aurora} --domain DOMAIN
+             {cloudflare,aurora,acmedns} --domain DOMAIN
              [--alt_domains [ALT_DOMAINS [ALT_DOMAINS ...]]]
              [--bundle_name BUNDLE_NAME] [--endpoint {production,staging}]
              [--email EMAIL] --action {run,renew}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Sewer currently only supports the DNS mode of validation, I have no plans of sup
 The currently supported DNS providers are:         
 1. [Cloudflare](https://www.cloudflare.com/dns)               
 2. [Aurora](https://www.pcextreme.com/aurora/dns)                 
-3. [Bring your own dns provider](#bring-your-own-dns-provider)   
+3. [acme-dns](https://github.com/joohoi/acme-dns)
+4. [Bring your own dns provider](#bring-your-own-dns-provider)
 ...                                      
 
 Sewer can be used very easliy programmatically as a library from code.            

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'requests', 'pyopenssl', 'cryptography', 'tldextract', 'apache-libcloud'
+        'requests', 'pyopenssl', 'cryptography', 'tldextract', 'apache-libcloud', 'dnspython'
     ],
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,

--- a/sewer/__init__.py
+++ b/sewer/__init__.py
@@ -3,3 +3,4 @@ from .client import Client  # noqa: F401
 from .dns_providers import BaseDns  # noqa: F401
 from .dns_providers import AuroraDns  # noqa: F401
 from .dns_providers import CloudFlareDns  # noqa: F401
+from .dns_providers import AcmeDnsDns  # noqa: F401

--- a/sewer/cli.py
+++ b/sewer/cli.py
@@ -52,7 +52,7 @@ def main():
         "--dns",
         type=str,
         required=True,
-        choices=['cloudflare', 'aurora'],
+        choices=['cloudflare', 'aurora', 'acmedns'],
         help="The name of the dns provider that you want to use.")
     parser.add_argument(
         "--domain",

--- a/sewer/cli.py
+++ b/sewer/cli.py
@@ -178,6 +178,28 @@ def main():
                 "ERROR:: Please supply {0} as an environment variable.".format(
                     str(e)))
             raise
+
+    elif dns_provider == 'acmedns':
+        from . import AcmeDnsDns
+        try:
+            ACME_DNS_SUBDOMAIN = os.environ['ACME_DNS_SUBDOMAIN']
+            ACME_DNS_API_USER = os.environ['ACME_DNS_API_USER']
+            ACME_DNS_API_KEY = os.environ['ACME_DNS_API_KEY']
+            ACME_DNS_API_BASE_URL = os.environ['ACME_DNS_API_BASE_URL']
+
+            dns_class = AcmeDnsDns(
+                ACME_DNS_SUBDOMAIN=ACME_DNS_SUBDOMAIN,
+                ACME_DNS_API_USER=ACME_DNS_API_USER,
+                ACME_DNS_API_KEY=ACME_DNS_API_KEY,
+                ACME_DNS_API_BASE_URL=ACME_DNS_API_BASE_URL)
+            logger.info(
+                'chosen_dns_provider. Using {0} as dns provider.'.format(
+                    dns_provider))
+        except KeyError as e:
+            logger.error(
+                "ERROR:: Please supply {0} as an environment variable.".format(
+                    str(e)))
+            raise
     else:
         raise ValueError(
             'The dns provider {0} is not recognised.'.format(dns_provider))

--- a/sewer/cli.py
+++ b/sewer/cli.py
@@ -182,13 +182,11 @@ def main():
     elif dns_provider == 'acmedns':
         from . import AcmeDnsDns
         try:
-            ACME_DNS_SUBDOMAIN = os.environ['ACME_DNS_SUBDOMAIN']
             ACME_DNS_API_USER = os.environ['ACME_DNS_API_USER']
             ACME_DNS_API_KEY = os.environ['ACME_DNS_API_KEY']
             ACME_DNS_API_BASE_URL = os.environ['ACME_DNS_API_BASE_URL']
 
             dns_class = AcmeDnsDns(
-                ACME_DNS_SUBDOMAIN=ACME_DNS_SUBDOMAIN,
                 ACME_DNS_API_USER=ACME_DNS_API_USER,
                 ACME_DNS_API_KEY=ACME_DNS_API_KEY,
                 ACME_DNS_API_BASE_URL=ACME_DNS_API_BASE_URL)

--- a/sewer/dns_providers/__init__.py
+++ b/sewer/dns_providers/__init__.py
@@ -1,3 +1,4 @@
 from .common import BaseDns  # noqa: F401
 from .auroradns import AuroraDns  # noqa: F401
 from .cloudflare import CloudFlareDns  # noqa: F401
+from .acmedns import AcmeDnsDns  # noqa: F401

--- a/sewer/dns_providers/acmedns.py
+++ b/sewer/dns_providers/acmedns.py
@@ -1,0 +1,66 @@
+import urllib.parse
+
+import requests
+
+from . import common
+
+
+class AcmeDnsDns(common.BaseDns):
+    """
+    """
+    dns_provider_name = 'acmedns'
+
+    def __init__(
+            self,
+            ACME_DNS_SUBDOMAIN,
+            ACME_DNS_API_USER,
+            ACME_DNS_API_KEY,
+            ACME_DNS_API_BASE_URL):
+        self.ACME_DNS_SUBDOMAIN = ACME_DNS_SUBDOMAIN
+        self.ACME_DNS_API_USER = ACME_DNS_API_USER
+        self.ACME_DNS_API_KEY = ACME_DNS_API_KEY
+        self.HTTP_TIMEOUT = 65  # seconds
+
+        if ACME_DNS_API_BASE_URL[-1] != '/':
+            self.ACME_DNS_API_BASE_URL = ACME_DNS_API_BASE_URL + '/'
+        else:
+            self.ACME_DNS_API_BASE_URL = ACME_DNS_API_BASE_URL
+        super(AcmeDnsDns, self).__init__()
+
+    def create_dns_record(self, domain_name, domain_dns_value):
+        self.logger.info('create_dns_record')
+        # if we have been given a wildcard name, strip wildcard
+        domain_name = domain_name.lstrip('*.')
+        # TODO determine subdomain based on domain_name
+
+        url = urllib.parse.urljoin(self.ACME_DNS_API_BASE_URL, 'update')
+        headers = {
+            'X-Api-User': self.ACME_DNS_API_USER,
+            'X-Api-Key': self.ACME_DNS_API_KEY,
+        }
+        body = {
+            "subdomain": self.ACME_DNS_SUBDOMAIN,
+            "txt": domain_dns_value,
+        }
+        update_acmedns_dns_record_response = requests.post(
+                url,
+                headers=headers,
+                json=body,
+                timeout=self.HTTP_TIMEOUT)
+        self.logger.debug(
+            'update_acmedns_dns_record_response. status_code={0}. response={1}'.format(
+                update_acmedns_dns_record_response.status_code,
+                self.log_response(update_acmedns_dns_record_response)))
+        if update_acmedns_dns_record_response.status_code != 200:
+            # raise error so that we do not continue to make calls to ACME
+            # server
+            raise ValueError(
+                "Error creating acme-dns dns record: status_code={status_code} response={response}". format(
+                    status_code=update_acmedns_dns_record_response.status_code,
+                    response=self.log_response(update_acmedns_dns_record_response)))
+        self.logger.info('create_dns_record_end')
+
+    def delete_dns_record(self, domain_name, domain_dns_value):
+        self.logger.info('delete_dns_record')
+        # acme-dns doesn't support this
+        self.logger.info('delete_dns_record_success')


### PR DESCRIPTION
[acme-dns](https://github.com/joohoi/acme-dns) is a simplified DNS server with a RESTful HTTP API to provide a simple way to automate ACME DNS challenges. This PR adds the necessary class to use any 3rd party or self-hosted _acme-dns_ instance with _sewer_. I tested this in the staging environment with my own domain running my own _acme-dns_ instance, and it generated the certificate successfully.