### PR TITLE
Update test_cloudflare.py

### DIFF
--- a/sewer/dns_providers/tests/test_cloudflare.py
+++ b/sewer/dns_providers/tests/test_cloudflare.py
@@ -74,8 +74,7 @@ class TestCloudflare(TestCase):
                 mock_requests_post.call_args[1]['headers'])
             self.assertDictEqual(
                 json.loads(
-                    expected['data']), json.loads(
-                    mock_requests_post.call_args[1]['data']))
+                    expected['data']), mock_requests_post.call_args[1]['json'])
 
     def test_cloudflare_is_called_by_delete_dns_record(self):
         with mock.patch('requests.post') as mock_requests_post, mock.patch(

--- a/sewer/dns_providers/tests/test_cloudflare.py
+++ b/sewer/dns_providers/tests/test_cloudflare.py
@@ -65,8 +65,7 @@ class TestCloudflare(TestCase):
             expected = {
                 'headers': {
                     'X-Auth-Email': self.CLOUDFLARE_EMAIL,
-                    'X-Auth-Key': self.CLOUDFLARE_API_KEY,
-                    'Content-Type': 'application/json'},
+                    'X-Auth-Key': self.CLOUDFLARE_API_KEY},
                 'data': '{"content": "mock-domain_dns_value", "type": "TXT", "name": "_acme-challenge.example.com."}',
                 'timeout': 65}
 
@@ -95,8 +94,7 @@ class TestCloudflare(TestCase):
             expected = {
                 'headers': {
                     'X-Auth-Email': self.CLOUDFLARE_EMAIL,
-                    'X-Auth-Key': self.CLOUDFLARE_API_KEY,
-                    'Content-Type': 'application/json'
+                    'X-Auth-Key': self.CLOUDFLARE_API_KEY
                 },
                 'timeout': 65
             }


### PR DESCRIPTION
content-type is no longer required

Thank you for contributing to sewer.                    
Every contribution to sewer is important to us.                       
You may not know it, but you have just contributed to making the world a more safer and secure place.                         

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to sewer, and sewer agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that sewer shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

## What(What have you changed?)
- rm content-type from cloudflare tests

## Why(Why did you change it?)
- as of https://github.com/komuw/sewer/pull/88 that is no longer required
