### PR TITLE
Allow certificate_key to be specified like account_key

### DIFF
--- a/sewer/cli.py
+++ b/sewer/cli.py
@@ -49,6 +49,12 @@ def main():
         help="The path to your letsencrypt/acme account key. \
         eg: --account_key /home/myaccount.key")
     parser.add_argument(
+        "--certificate_key",
+        type=argparse.FileType('r'),
+        required=False,
+        help="The path to your certificate key. \
+        eg: --certificate_key /home/mycertificate.key")
+    parser.add_argument(
         "--dns",
         type=str,
         required=True,
@@ -116,6 +122,7 @@ def main():
     alt_domains = args.alt_domains
     action = args.action
     account_key = args.account_key
+    certificate_key = args.certificate_key
     bundle_name = args.bundle_name
     endpoint = args.endpoint
     email = args.email
@@ -131,6 +138,8 @@ def main():
 
     if account_key:
         account_key = account_key.read()
+    if certificate_key:
+        certificate_key = certificate_key.read()
     if bundle_name:
         file_name = bundle_name
     else:
@@ -208,6 +217,7 @@ def main():
         domain_alt_names=alt_domains,
         contact_email=email,
         account_key=account_key,
+        certificate_key=certificate_key,
         ACME_DIRECTORY_URL=ACME_DIRECTORY_URL,
         LOG_LEVEL=loglevel)
     certificate_key = client.certificate_key

--- a/sewer/client.py
+++ b/sewer/client.py
@@ -58,6 +58,7 @@ class Client(object):
             domain_alt_names=None,
             contact_email=None,
             account_key=None,
+            certificate_key=None,
             bits=2048,
             digest='sha256',
             ACME_REQUEST_TIMEOUT=7,
@@ -76,6 +77,9 @@ class Client(object):
             a contact email address
         :param account_key:                  (optional) [string]
             a string whose contents is an ssl certificate that identifies your account on the acme server.
+            if you do not provide one, this client will issue a new certificate else will renew.
+        :param certificate_key:              (optional) [string]
+            a string whose contents is a private key that will be incorporated into your new certificate.
             if you do not provide one, this client will issue a new certificate else will renew.
         :param bits:                         (optional) [integer]
             number of bits that will be used to create your certificates' private key.
@@ -105,6 +109,10 @@ class Client(object):
             raise ValueError(
                 """account_key should be of type:: None or str. You entered {0}.
                 More specifically, account_key should be the result of reading an ssl account certificate""".format(type(account_key)))
+        elif not isinstance(certificate_key, (type(None), str)):
+            raise ValueError(
+                """certificate_key should be of type:: None or str. You entered {0}.
+                More specifically, certificate_key should be the result of reading an ssl certificate""".format(type(certificate_key)))
         elif LOG_LEVEL.upper() not in ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']:
             raise ValueError(
                 """LOG_LEVEL should be one of; 'DEBUG', 'INFO', 'WARNING', 'ERROR' or 'CRITICAL'. not {0}""".format(LOG_LEVEL))
@@ -148,7 +156,7 @@ class Client(object):
             # https://tools.ietf.org/html/draft-ietf-acme-acme#section-6.2
             self.kid = None
 
-            self.certificate_key = self.create_certificate_key()
+            self.certificate_key = certificate_key or self.create_certificate_key()
             self.csr = self.create_csr()
 
             if not account_key:


### PR DESCRIPTION
## What

I added an option to the `Client` constructor named `certificate_key` which behaves just like the optional parameter `account_key` -- it allows the user to specify a private key instead of generating one.

## Why

While I'm all for generating new keys upon each renewal as it dramatically lowers the time window in which a leaked key can be abused, there are situations when a pre-existing key must be used.

For example if [HPKP](https://en.wikipedia.org/wiki/HTTP_Public_Key_Pinning) is already set up and clients expects private keys to be selected from a limited pool already advertised in the header, there's no other option but to generate a certificate that matches at least one of the entries already known by User-Agents.