### PR TITLE
check authorizations after challenge responses

### DIFF
--- a/sewer/client.py
+++ b/sewer/client.py
@@ -446,7 +446,7 @@ class Client(object):
 
         return acme_keyauthorization, base64_of_acme_keyauthorization
 
-    def check_authorization_status(self, authorization_url, desired_status=["pending", "valid"]):
+    def check_authorization_status(self, authorization_url, desired_status=None):
         """
         https://tools.ietf.org/html/draft-ietf-acme-acme#section-7.5.1
         To check on the status of an authorization, the client sends a GET(polling)
@@ -462,6 +462,7 @@ class Client(object):
         client via the "errors" field in the challenge and the Retry-After
         """
         self.logger.info("check_authorization_status")
+        desired_status = desired_status or ["pending", "valid"]
         number_of_checks = 0
         while True:
             headers = {"User-Agent": self.User_Agent}

--- a/sewer/tests/test_utils.py
+++ b/sewer/tests/test_utils.py
@@ -39,7 +39,7 @@ class MockResponse(object):
                 ],
                 "authorizations": ["http://localhost/authorization-url"],
                 "finalize": "http://localhost/finalize-url",
-                "status": "pending",
+                "status": "valid",
                 "certificate": "http://localhost/certificate-url",
                 "meta": {"termsOfService": "http:localhost/termsOfService"},
                 "dummy-certificate": "-----BEGIN CERTIFICATE----- some-mock-certificate -----END CERTIFICATE-----",


### PR DESCRIPTION

## What have you changed?

I've changed some of the logic in `get_certificate` to call `check_authorization_status()` twice instead of just once. There are a couple of reasons for this:
- After submitting a challenge response, the client wasn't waiting for the authorization to transition to the `valid` status, if it was in the `pending` status before that. The ACME server might have not had enough time to run the validation of the DNS challenge to transition the authorization to the `valid` state.
- An authorization could have been successfully handled by a previous run of sewer for a hostname or set of hostnames. LetsEncrypt in particular caches valid authorizations for 30 days, so if you're requesting a new certificate for a hostname which you had already proved ownership, recently, then you should not submit a challenge for it.

## Why did you change it?

I was getting a 403 error in `send_csr`: `{'detail': 'Error finalizing order :: authorizations for these names not found or expired: rolodex.example.com', 'type': 'urn:ietf:params:acme:error:unauthorized', 'status': 403}`. This is described in more detail in #109.

I adjusted the unit tests to better suite the modified logic. Particularly, the `test_respond_to_challenge_called` is validated by mocking a `{"status": "pending"}` response from `check_authorization_status()`. All the other tests don't go through that path (they are given a `{"status": "valid"}` response)