### PR TITLE
added provider name checking in domain_name string

### DIFF
--- a/sewer/dns_providers/duckdns.py
+++ b/sewer/dns_providers/duckdns.py
@@ -23,6 +23,10 @@ class DuckDNSDns(common.BaseDns):
         self.logger.info("{0}".format(logger_info))
         # if we have been given a wildcard name, strip wildcard
         domain_name = domain_name.lstrip("*.")
+        # add provider domain to the domain name if not present
+        provider_domain = ".duckdns.org"
+        if domain_name.rfind(provider_domain) == -1:
+            "".join((domain_name, provider_domain))
 
         url = urllib.parse.urljoin(self.DUCKDNS_API_BASE_URL, "update")
 


### PR DESCRIPTION
## What(What have you changed?)
added provider name checking in domain_name string for DuckDNS.

## Why(Why did you change it?)
Because in the Home Assistant plugin parameter for duckdns we can add domain name with and without the string part of the provider name. (i'm working on the plugin)
