### PR TITLE
Added logger name that identify the package

### DIFF
--- a/sewer/dns_providers/common.py
+++ b/sewer/dns_providers/common.py
@@ -9,7 +9,7 @@ class BaseDns(object):
         self.LOG_LEVEL = LOG_LEVEL
         self.dns_provider_name = self.__class__.__name__
 
-        self.logger = logging.getLogger()
+        self.logger = logging.getLogger('sewer')
         handler = logging.StreamHandler()
         formatter = logging.Formatter("%(message)s")
         handler.setFormatter(formatter)

--- a/sewer/dns_providers/common.py
+++ b/sewer/dns_providers/common.py
@@ -9,7 +9,7 @@ class BaseDns(object):
         self.LOG_LEVEL = LOG_LEVEL
         self.dns_provider_name = self.__class__.__name__
 
-        self.logger = logging.getLogger('sewer')
+        self.logger = logging.getLogger("sewer")
         handler = logging.StreamHandler()
         formatter = logging.Formatter("%(message)s")
         handler.setFormatter(formatter)


### PR DESCRIPTION
## What(What have you changed?)
Added logger name under common.py providers path that identify the package.

## Why(Why did you change it?)
I proposed this patch because, by default, each call to the logger is identified with "root" name.
this edit is useful when the package is used inside another one considering that, we can identify easily the log provenience.  
