### PR TITLE
Moves sleep before the initial verification call.

### DIFF
--- a/sewer/client.py
+++ b/sewer/client.py
@@ -465,6 +465,7 @@ class Client(object):
         desired_status = desired_status or ["pending", "valid"]
         number_of_checks = 0
         while True:
+            time.sleep(self.ACME_AUTH_STATUS_WAIT_PERIOD)
             headers = {"User-Agent": self.User_Agent}
             check_authorization_status_response = requests.get(
                 authorization_url, timeout=self.ACME_REQUEST_TIMEOUT, headers=headers
@@ -488,9 +489,6 @@ class Client(object):
 
             if authorization_status in desired_status:
                 break
-            else:
-                # for any other status, sleep then retry
-                time.sleep(self.ACME_AUTH_STATUS_WAIT_PERIOD)
 
         self.logger.info("check_authorization_status_success")
         return check_authorization_status_response


### PR DESCRIPTION
Thank you for contributing to sewer.                    
Every contribution to sewer is important to us.                       
You may not know it, but you have just contributed to making the world a more safer and secure place.                         

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to sewer, and sewer agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that sewer shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

## What(What have you changed?)
I moved the wait period to the beginning of the loop, before the first verification.

## Why(Why did you change it?)
I could not get sewer to work with my dns provider without this fix. No matter what amount of time I would set the wait period for, it would fail. I'm not exactly sure why this is (dns caching? stale dns anycast records?), but I noticed that other libraries have the wait time before the initial check.

Fixes: https://github.com/komuw/sewer/issues/115
