### PR TITLE
Fix logging

### DIFF
--- a/sewer/client.py
+++ b/sewer/client.py
@@ -147,7 +147,7 @@ class Client(object):
         self.ACME_DIRECTORY_URL = ACME_DIRECTORY_URL
         self.LOG_LEVEL = LOG_LEVEL.upper()
 
-        self.logger = logging.getLogger()
+        self.logger = logging.getLogger(__name__)
         handler = logging.StreamHandler()
         formatter = logging.Formatter("%(message)s")
         handler.setFormatter(formatter)

--- a/sewer/dns_providers/common.py
+++ b/sewer/dns_providers/common.py
@@ -9,7 +9,7 @@ class BaseDns(object):
         self.LOG_LEVEL = LOG_LEVEL
         self.dns_provider_name = self.__class__.__name__
 
-        self.logger = logging.getLogger("sewer")
+        self.logger = logging.getLogger(__name__)
         handler = logging.StreamHandler()
         formatter = logging.Formatter("%(message)s")
         handler.setFormatter(formatter)


### PR DESCRIPTION
## What(What have you changed?)

Loggers used by sewer.

## Why(Why did you change it?)

The client is redefining root logger. It should not as it's messing with any project importing sewer and already having a logging system in place.

In a project with a lot of sub-modules, the general logging level is set at the root logger level and propagated to all sub-logger of each sub-modules (using `logging.getLogger(__name__)`).
But then, let's say you want to create a sewer client with only error logging level while the rest is at info, you would run something like `sewer.Client(..., LOG_LEVEL="ERROR")` but this will change ALL the other loggers that are completely unrelated to sewer to ERROR too(!) as they are children of the root logger.

Also, it probably doesn't make sense to use a named logger like `logging.getLogger("sewer")` as the logger is already managed in the object and can be accessed like `client.logger`.

If you @komuw feel like a named logger would be better, you might as well remove the logger from the object and just use a global `_log = logging.getLogger("sewer")` in each file.

Really hope to see that merged because sewer is a cool tool but the logging is lacking best practices and makes it a pain to integrate in bigger projects.

Thanks in advance