### PR TITLE
Add Cloudflare token auth support and fix Route53 imports

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Which version of python are you using?
 
-## What operating system and version of operating system are you uing?
+## What operating system and version of operating system are you using?
 
 ## What version of sewer are you using?
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,3 +22,4 @@ Contributors
 8. [Harold Bradley III](https://haroldbradleyiii.com/)
 9. [@etienne-napoleone](https://github.com/etienne-napoleone)
 10. [@soloradish](https://github.com/soloradish)
+11. [Moritz Ulmer](https://www.protohaus.org)

--- a/sewer/cli.py
+++ b/sewer/cli.py
@@ -189,17 +189,25 @@ def main():
     if dns_provider == "cloudflare":
         from . import CloudFlareDns
 
-        try:
-            CLOUDFLARE_EMAIL = os.environ["CLOUDFLARE_EMAIL"]
-            CLOUDFLARE_API_KEY = os.environ["CLOUDFLARE_API_KEY"]
+        CLOUDFLARE_EMAIL = os.environ.get("CLOUDFLARE_EMAIL", None)
+        CLOUDFLARE_API_KEY = os.environ.get("CLOUDFLARE_API_KEY", None)
+        CLOUDFLARE_TOKEN = os.environ.get("CLOUDFLARE_TOKEN", None)
 
+        if CLOUDFLARE_EMAIL and CLOUDFLARE_API_KEY and not CLOUDFLARE_TOKEN:
             dns_class = CloudFlareDns(
                 CLOUDFLARE_EMAIL=CLOUDFLARE_EMAIL, CLOUDFLARE_API_KEY=CLOUDFLARE_API_KEY
             )
-            logger.info("chosen_dns_provider. Using {0} as dns provider.".format(dns_provider))
-        except KeyError as e:
-            logger.error("ERROR:: Please supply {0} as an environment variable.".format(str(e)))
-            raise
+        elif CLOUDFLARE_TOKEN and not CLOUDFLARE_EMAIL and not CLOUDFLARE_API_KEY:
+            dns_class = CloudFlareDns(CLOUDFLARE_TOKEN=CLOUDFLARE_TOKEN)
+        else:
+            err = (
+                "ERROR:: Please supply either CLOUDFLARE_EMAIL and CLOUDFLARE_API_KEY"
+                "or CLOUDFLARE_TOKEN as environment variables."
+            )
+            logger.error(err)
+            raise KeyError(err)
+
+        logger.info("chosen_dns_provider. Using {0} as dns provider.".format(dns_provider))
 
     elif dns_provider == "aurora":
         from . import AuroraDns

--- a/sewer/dns_providers/cloudflare.py
+++ b/sewer/dns_providers/cloudflare.py
@@ -164,7 +164,6 @@ class CloudFlareDns(common.BaseDns):
 
     def _get_auth_header(self):
         if self.CLOUDFLARE_TOKEN:
-            print(self.CLOUDFLARE_TOKEN)
             return {"Authorization": "Bearer " + self.CLOUDFLARE_TOKEN}
         else:
             return {"X-Auth-Email": self.CLOUDFLARE_EMAIL, "X-Auth-Key": self.CLOUDFLARE_API_KEY}

--- a/sewer/dns_providers/cloudflare.py
+++ b/sewer/dns_providers/cloudflare.py
@@ -13,26 +13,38 @@ class CloudFlareDns(common.BaseDns):
 
     def __init__(
         self,
-        CLOUDFLARE_EMAIL,
-        CLOUDFLARE_API_KEY,
+        CLOUDFLARE_EMAIL=None,
+        CLOUDFLARE_API_KEY=None,
         CLOUDFLARE_API_BASE_URL="https://api.cloudflare.com/client/v4/",
+        CLOUDFLARE_TOKEN=None,
     ):
         self.CLOUDFLARE_DNS_ZONE_ID = None
         self.CLOUDFLARE_EMAIL = CLOUDFLARE_EMAIL
         self.CLOUDFLARE_API_KEY = CLOUDFLARE_API_KEY
         self.CLOUDFLARE_API_BASE_URL = CLOUDFLARE_API_BASE_URL
+        self.CLOUDFLARE_TOKEN = CLOUDFLARE_TOKEN
         self.HTTP_TIMEOUT = 65  # seconds
 
         if CLOUDFLARE_API_BASE_URL[-1] != "/":
             self.CLOUDFLARE_API_BASE_URL = CLOUDFLARE_API_BASE_URL + "/"
         else:
             self.CLOUDFLARE_API_BASE_URL = CLOUDFLARE_API_BASE_URL
+
+        # Either only pass a token or only the email and API key
+        if not (
+            (CLOUDFLARE_TOKEN and not CLOUDFLARE_EMAIL and not CLOUDFLARE_API_KEY)
+            or (not CLOUDFLARE_TOKEN and CLOUDFLARE_EMAIL and CLOUDFLARE_API_KEY)
+        ):
+            raise ValueError(
+                "Error initializing Cloudflare DNS adapter. Pass either email and API key or a token."
+            )
+
         super(CloudFlareDns, self).__init__()
 
     def find_dns_zone(self, domain_name):
         self.logger.debug("find_dns_zone")
         url = urllib.parse.urljoin(self.CLOUDFLARE_API_BASE_URL, "zones?status=active")
-        headers = {"X-Auth-Email": self.CLOUDFLARE_EMAIL, "X-Auth-Key": self.CLOUDFLARE_API_KEY}
+        headers = self._get_auth_header()
         find_dns_zone_response = requests.get(url, headers=headers, timeout=self.HTTP_TIMEOUT)
         self.logger.debug(
             "find_dns_zone_response. status_code={0}".format(find_dns_zone_response.status_code)
@@ -70,7 +82,7 @@ class CloudFlareDns(common.BaseDns):
             self.CLOUDFLARE_API_BASE_URL,
             "zones/{0}/dns_records".format(self.CLOUDFLARE_DNS_ZONE_ID),
         )
-        headers = {"X-Auth-Email": self.CLOUDFLARE_EMAIL, "X-Auth-Key": self.CLOUDFLARE_API_KEY}
+        headers = self._get_auth_header()
         body = {
             "type": "TXT",
             "name": "_acme-challenge" + "." + domain_name + ".",
@@ -109,7 +121,7 @@ class CloudFlareDns(common.BaseDns):
                 return {}
 
         delete_dns_record_response = MockResponse()
-        headers = {"X-Auth-Email": self.CLOUDFLARE_EMAIL, "X-Auth-Key": self.CLOUDFLARE_API_KEY}
+        headers = self._get_auth_header()
 
         dns_name = "_acme-challenge" + "." + domain_name
         list_dns_payload = {"type": "TXT", "name": dns_name}
@@ -128,7 +140,7 @@ class CloudFlareDns(common.BaseDns):
                 self.CLOUDFLARE_API_BASE_URL,
                 "zones/{0}/dns_records/{1}".format(self.CLOUDFLARE_DNS_ZONE_ID, dns_record_id),
             )
-            headers = {"X-Auth-Email": self.CLOUDFLARE_EMAIL, "X-Auth-Key": self.CLOUDFLARE_API_KEY}
+            headers = self._get_auth_header()
             delete_dns_record_response = requests.delete(
                 url, headers=headers, timeout=self.HTTP_TIMEOUT
             )
@@ -149,3 +161,10 @@ class CloudFlareDns(common.BaseDns):
                 )
 
         self.logger.info("delete_dns_record_success")
+
+    def _get_auth_header(self):
+        if self.CLOUDFLARE_TOKEN:
+            print(self.CLOUDFLARE_TOKEN)
+            return {"Authorization": "Bearer " + self.CLOUDFLARE_TOKEN}
+        else:
+            return {"X-Auth-Email": self.CLOUDFLARE_EMAIL, "X-Auth-Key": self.CLOUDFLARE_API_KEY}

--- a/sewer/dns_providers/route53.py
+++ b/sewer/dns_providers/route53.py
@@ -1,6 +1,11 @@
 import collections
-import boto3
-from botocore.client import Config
+
+try:
+    route53_dependencies = True
+    import boto3
+    from botocore.client import Config
+except ImportError:
+    route53_dependencies = False
 
 from . import common
 
@@ -12,6 +17,11 @@ class Route53Dns(common.BaseDns):
     read_timeout = 30
 
     def __init__(self, access_key_id=None, secret_access_key=None):
+        if not route53_dependencies:
+            raise ImportError(
+                """You need to install Route53Dns dependencies. run; pip3 install sewer[route53]"""
+            )
+
         self.aws_config = Config(
             connect_timeout=self.connect_timeout, read_timeout=self.read_timeout
         )

--- a/sewer/dns_providers/tests/test_cloudflare.py
+++ b/sewer/dns_providers/tests/test_cloudflare.py
@@ -17,15 +17,26 @@ class TestCloudflare(TestCase):
         self.CLOUDFLARE_EMAIL = "mock-email@example.com"
         self.CLOUDFLARE_API_KEY = "mock-api-key"
         self.CLOUDFLARE_API_BASE_URL = "https://some-mock-url.com"
+        self.CLOUDFLARE_TOKEN = "mock-token"
 
         with mock.patch("requests.post") as mock_requests_post, mock.patch(
             "requests.get"
         ) as mock_requests_get:
             mock_requests_post.return_value = test_utils.MockResponse()
             mock_requests_get.return_value = test_utils.MockResponse()
-            self.dns_class = sewer.CloudFlareDns(
+            self.dns_class_api_key = sewer.CloudFlareDns(
                 CLOUDFLARE_EMAIL=self.CLOUDFLARE_EMAIL,
                 CLOUDFLARE_API_KEY=self.CLOUDFLARE_API_KEY,
+                CLOUDFLARE_API_BASE_URL=self.CLOUDFLARE_API_BASE_URL,
+            )
+
+        with mock.patch("requests.post") as mock_requests_post, mock.patch(
+            "requests.get"
+        ) as mock_requests_get:
+            mock_requests_post.return_value = test_utils.MockResponse()
+            mock_requests_get.return_value = test_utils.MockResponse()
+            self.dns_class_token = sewer.CloudFlareDns(
+                CLOUDFLARE_TOKEN=self.CLOUDFLARE_TOKEN,
                 CLOUDFLARE_API_BASE_URL=self.CLOUDFLARE_API_BASE_URL,
             )
 
@@ -44,7 +55,12 @@ class TestCloudflare(TestCase):
                 mock_requests_delete.return_value
             ) = mock_delete_dns_record.return_value = test_utils.MockResponse()
 
-            self.dns_class.create_dns_record(
+            self.dns_class_api_key.create_dns_record(
+                domain_name=self.domain_name, domain_dns_value=self.domain_dns_value
+            )
+            self.assertFalse(mock_delete_dns_record.called)
+
+            self.dns_class_token.create_dns_record(
                 domain_name=self.domain_name, domain_dns_value=self.domain_dns_value
             )
             self.assertFalse(mock_delete_dns_record.called)
@@ -61,7 +77,8 @@ class TestCloudflare(TestCase):
                 mock_requests_delete.return_value
             ) = mock_delete_dns_record.return_value = test_utils.MockResponse()
 
-            self.dns_class.create_dns_record(
+            # Test with API key authentication
+            self.dns_class_api_key.create_dns_record(
                 domain_name=self.domain_name, domain_dns_value=self.domain_dns_value
             )
             expected = {
@@ -69,6 +86,21 @@ class TestCloudflare(TestCase):
                     "X-Auth-Email": self.CLOUDFLARE_EMAIL,
                     "X-Auth-Key": self.CLOUDFLARE_API_KEY,
                 },
+                "data": '{"content": "mock-domain_dns_value", "type": "TXT", "name": "_acme-challenge.example.com."}',
+                "timeout": 65,
+            }
+
+            self.assertDictEqual(expected["headers"], mock_requests_post.call_args[1]["headers"])
+            self.assertDictEqual(
+                json.loads(expected["data"]), mock_requests_post.call_args[1]["json"]
+            )
+
+            # Test with token authentication
+            self.dns_class_token.create_dns_record(
+                domain_name=self.domain_name, domain_dns_value=self.domain_dns_value
+            )
+            expected = {
+                "headers": {"Authorization": "Bearer " + self.CLOUDFLARE_TOKEN},
                 "data": '{"content": "mock-domain_dns_value", "type": "TXT", "name": "_acme-challenge.example.com."}',
                 "timeout": 65,
             }
@@ -88,7 +120,8 @@ class TestCloudflare(TestCase):
 
             mock_requests_get.return_value = test_utils.MockResponse()
 
-            self.dns_class.delete_dns_record(
+            # Test with API key authentication
+            self.dns_class_api_key.delete_dns_record(
                 domain_name=self.domain_name, domain_dns_value=self.domain_dns_value
             )
             self.assertTrue(mock_requests_get.called)
@@ -104,3 +137,57 @@ class TestCloudflare(TestCase):
                 "https://some-mock-url.com/zones/None/dns_records/some-mock-dns-zone-id",
                 str(mock_requests_delete.call_args),
             )
+
+            # Test with token authentication
+            self.dns_class_token.delete_dns_record(
+                domain_name=self.domain_name, domain_dns_value=self.domain_dns_value
+            )
+            self.assertTrue(mock_requests_get.called)
+            expected = {
+                "headers": {"Authorization": "Bearer " + self.CLOUDFLARE_TOKEN},
+                "timeout": 65,
+            }
+            self.assertDictEqual(expected, mock_requests_delete.call_args[1])
+            self.assertIn(
+                "https://some-mock-url.com/zones/None/dns_records/some-mock-dns-zone-id",
+                str(mock_requests_delete.call_args),
+            )
+
+
+class TestCloudflareTokens(TestCase):
+    """
+    Test that the authorization parameters are validated (either email + API key or token)
+    """
+
+    def setUp(self):
+        self.CLOUDFLARE_EMAIL = "mock-email@example.com"
+        self.CLOUDFLARE_API_KEY = "mock-api-key"
+        self.CLOUDFLARE_TOKEN = "some-token"
+
+    def test_init_auth_validation(self):
+        # Invalid inputs
+        with self.assertRaises(ValueError):
+            sewer.CloudFlareDns(
+                CLOUDFLARE_TOKEN=self.CLOUDFLARE_TOKEN,
+                CLOUDFLARE_EMAIL=self.CLOUDFLARE_EMAIL,
+                CLOUDFLARE_API_KEY=self.CLOUDFLARE_API_KEY,
+            )
+
+        with self.assertRaises(ValueError):
+            sewer.CloudFlareDns(
+                CLOUDFLARE_TOKEN=self.CLOUDFLARE_TOKEN, CLOUDFLARE_API_KEY=self.CLOUDFLARE_API_KEY
+            )
+
+        with self.assertRaises(ValueError):
+            sewer.CloudFlareDns()
+
+        with self.assertRaises(ValueError):
+            sewer.CloudFlareDns(
+                CLOUDFLARE_TOKEN=self.CLOUDFLARE_TOKEN, CLOUDFLARE_EMAIL=self.CLOUDFLARE_EMAIL
+            )
+
+        # Valid inputs
+        sewer.CloudFlareDns(
+            CLOUDFLARE_EMAIL=self.CLOUDFLARE_EMAIL, CLOUDFLARE_API_KEY=self.CLOUDFLARE_API_KEY
+        )
+        sewer.CloudFlareDns(CLOUDFLARE_TOKEN=self.CLOUDFLARE_TOKEN)


### PR DESCRIPTION
Thank you for contributing to sewer.                    
Every contribution to sewer is important to us.                       
You may not know it, but you have just contributed to making the world a more safer and secure place.

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to sewer, and sewer agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that sewer shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

## What(What have you changed?)
- Added support for tokens in Cloudflare DNS
- Fixed how Route53 imports dependencies

## Why(Why did you change it?)
- Tokens allow limiting the API functionality to the token
  - API keys allow access to all functionality
- Route53 throws import errors even when not used
- Fixes: https://github.com/komuw/sewer/issues/127