### PR TITLE
Fix #136 - don't install handler if logger already has ancestral hand…

### DIFF
--- a/sewer/client.py
+++ b/sewer/client.py
@@ -148,12 +148,12 @@ class Client(object):
         self.LOG_LEVEL = LOG_LEVEL.upper()
 
         self.logger = logging.getLogger(__name__)
-        handler = logging.StreamHandler()
-        formatter = logging.Formatter("%(message)s")
-        handler.setFormatter(formatter)
-        if not self.logger.handlers:
-            self.logger.addHandler(handler)
         self.logger.setLevel(self.LOG_LEVEL)
+        if not self.logger.hasHandlers():
+            handler = logging.StreamHandler()
+            formatter = logging.Formatter("%(message)s")
+            handler.setFormatter(formatter)
+            self.logger.addHandler(handler)
 
         try:
             self.all_domain_names = copy.copy(self.domain_alt_names)

--- a/sewer/dns_providers/common.py
+++ b/sewer/dns_providers/common.py
@@ -10,12 +10,12 @@ class BaseDns(object):
         self.dns_provider_name = self.__class__.__name__
 
         self.logger = logging.getLogger(__name__)
-        handler = logging.StreamHandler()
-        formatter = logging.Formatter("%(message)s")
-        handler.setFormatter(formatter)
-        if not self.logger.handlers:
-            self.logger.addHandler(handler)
         self.logger.setLevel(self.LOG_LEVEL)
+        if not self.logger.hasHandlers():
+            handler = logging.StreamHandler()
+            formatter = logging.Formatter("%(message)s")
+            handler.setFormatter(formatter)
+            self.logger.addHandler(handler)
 
     def log_response(self, response):
         """


### PR DESCRIPTION
…lers

Thank you for contributing to sewer.                    
Every contribution to sewer is important to us.                       
You may not know it, but you have just contributed to making the world a more safer and secure place.                         

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to sewer, and sewer agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that sewer shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

## What(What have you changed?)

Fix #136 - only attach handler to client logger if there is not already an ancestral logger with a handler, so log messages aren't doubled.

## Why(Why did you change it?)

Those doubled messages are unsightly at best.  Besides, it looks like the existing code's intent was to avoid this - maybe followed an example for an earlier version of logging before hasHandlers() was added?

Updated, now two commits - fixed same issue in the dns common.py, though I don't remember seeing those duplicated during testing.  Of course I had a lot of failing runs before it got as far as calling into the dns driver.  :-/