### PR TITLE
Wrap requests.[get,head,post] calls to allow one-point injection of common…

### DIFF
--- a/sewer/client.py
+++ b/sewer/client.py
@@ -196,7 +196,7 @@ class Client(object):
 
     def GET(self, url, **kwargs):
         """
-        wrap requests.get to allow:
+        wrap requests.get (also post and head, below) to allow:
           * injection of e.g. UserAgent header in one place rather than all over
           * hides requests itself to allow for change (unlikely) or use of Session
           # paves the way to inject the verify option, required to use pebble
@@ -205,15 +205,14 @@ class Client(object):
         return self._request("GET", url, **kwargs)
 
     def POST(self, url, **kwargs):
-        """
-        wrap requests.post for all the reasons listed for GET
-        """
-
         return self._request("POST", url, **kwargs)
+
+    def HEAD(self, url, **kwargs):
+        return self._request("HEAD", url, **kwargs)
 
     def _request(self, method, url, **kwargs):
         """
-        shared implementation for GET and POST
+        shared implementation for GET, HEAD and POST
         """
 
         # if there's no UserAgent header in args, inject it
@@ -225,7 +224,8 @@ class Client(object):
         if "timeout" not in kwargs:
             kwargs["timeout"] = self.ACME_REQUEST_TIMEOUT
 
-        return requests.request(method, url, **kwargs)
+        response = requests.request(method, url, **kwargs)
+        return response
 
     @staticmethod
     def log_response(response):
@@ -618,7 +618,7 @@ class Client(object):
         in order to protect against replay attacks.
         """
         self.logger.debug("get_nonce")
-        response = self.GET(self.ACME_GET_NONCE_URL)
+        response = self.HEAD(self.ACME_GET_NONCE_URL)
         nonce = response.headers["Replay-Nonce"]
         return nonce
 

--- a/sewer/client.py
+++ b/sewer/client.py
@@ -194,6 +194,39 @@ class Client(object):
             self.logger.error("Unable to intialise client. error={0}".format(str(e)))
             raise e
 
+    def GET(self, url, **kwargs):
+        """
+        wrap requests.get to allow:
+          * injection of e.g. UserAgent header in one place rather than all over
+          * hides requests itself to allow for change (unlikely) or use of Session
+          # paves the way to inject the verify option, required to use pebble
+        """
+
+        return self._request("GET", url, **kwargs)
+
+    def POST(self, url, **kwargs):
+        """
+        wrap requests.post for all the reasons listed for GET
+        """
+
+        return self._request("POST", url, **kwargs)
+
+    def _request(self, method, url, **kwargs):
+        """
+        shared implementation for GET and POST
+        """
+
+        # if there's no UserAgent header in args, inject it
+        headers = kwargs.setdefault("headers", {})
+        if "UserAgent" not in headers:
+            headers["UserAgent"] = self.User_Agent
+
+        # add standard timeout if there's none already present
+        if "timeout" not in kwargs:
+            kwargs["timeout"] = self.ACME_REQUEST_TIMEOUT
+
+        return requests.request(method, url, **kwargs)
+
     @staticmethod
     def log_response(response):
         """
@@ -218,10 +251,7 @@ class Client(object):
 
     def get_acme_endpoints(self):
         self.logger.debug("get_acme_endpoints")
-        headers = {"User-Agent": self.User_Agent}
-        get_acme_endpoints = requests.get(
-            self.ACME_DIRECTORY_URL, timeout=self.ACME_REQUEST_TIMEOUT, headers=headers
-        )
+        get_acme_endpoints = self.GET(self.ACME_DIRECTORY_URL)
         self.logger.debug(
             "get_acme_endpoints_response. status_code={0}".format(get_acme_endpoints.status_code)
         )
@@ -389,10 +419,7 @@ class Client(object):
         This is also where we get the challenges/tokens.
         """
         self.logger.info("get_identifier_authorization")
-        headers = {"User-Agent": self.User_Agent}
-        get_identifier_authorization_response = requests.get(
-            url, timeout=self.ACME_REQUEST_TIMEOUT, headers=headers
-        )
+        get_identifier_authorization_response = self.GET(url)
         self.logger.debug(
             "get_identifier_authorization_response. status_code={0}. response={1}".format(
                 get_identifier_authorization_response.status_code,
@@ -466,10 +493,7 @@ class Client(object):
         number_of_checks = 0
         while True:
             time.sleep(self.ACME_AUTH_STATUS_WAIT_PERIOD)
-            headers = {"User-Agent": self.User_Agent}
-            check_authorization_status_response = requests.get(
-                authorization_url, timeout=self.ACME_REQUEST_TIMEOUT, headers=headers
-            )
+            check_authorization_status_response = self.GET(authorization_url)
             authorization_status = check_authorization_status_response.json()["status"]
             number_of_checks = number_of_checks + 1
             self.logger.debug(
@@ -594,10 +618,7 @@ class Client(object):
         in order to protect against replay attacks.
         """
         self.logger.debug("get_nonce")
-        headers = {"User-Agent": self.User_Agent}
-        response = requests.get(
-            self.ACME_GET_NONCE_URL, timeout=self.ACME_REQUEST_TIMEOUT, headers=headers
-        )
+        response = self.GET(self.ACME_GET_NONCE_URL)
         nonce = response.headers["Replay-Nonce"]
         return nonce
 
@@ -666,11 +687,11 @@ class Client(object):
 
     def make_signed_acme_request(self, url, payload):
         self.logger.debug("make_signed_acme_request")
-        headers = {"User-Agent": self.User_Agent}
+        headers = {}
         payload = self.stringfy_items(payload)
 
         if payload in ["GET_Z_CHALLENGE", "DOWNLOAD_Z_CERTIFICATE"]:
-            response = requests.get(url, timeout=self.ACME_REQUEST_TIMEOUT, headers=headers)
+            response = self.GET(url, headers=headers)
         else:
             payload64 = self.calculate_safe_base64(json.dumps(payload))
             protected = self.get_acme_header(url)
@@ -681,8 +702,8 @@ class Client(object):
                 {"protected": protected64, "payload": payload64, "signature": signature64}
             )
             headers.update({"Content-Type": "application/jose+json"})
-            response = requests.post(
-                url, data=data.encode("utf8"), timeout=self.ACME_REQUEST_TIMEOUT, headers=headers
+            response = self.POST(
+                url, data=data.encode("utf8"), headers=headers
             )
         return response
 


### PR DESCRIPTION
… options

## What(What have you changed?)

added self.[GET,POST] and their shared implementaion in self._requests to client.py

converted direct calls to requests.[get,post] with self.[GET,POST]

refactored injection of UserAgent and timeout: added to _requests, removed from call sites

## Why(Why did you change it?)

This sets the stage for
 * further refactoring of common settings?
 * possible refactoring of request failure reporting
 * potential for single-point addition of retrying requests when appropriate

Both UserAgent and timeout request parameters have been refactored already.

**Off-label use**: the wrappers themselves are a spin-off from my early work getting sewer to run against the pebble test server.  The specific need there is to inject verify=CA_cert_path into every request in order not to fail on pebble's intentionally bogus CA certificate.  (alternative would be verify=False, and that may be the way to go when running with --dns=pebble).