### PR TITLE
Smart nonces

### DIFF
--- a/sewer/client.py
+++ b/sewer/client.py
@@ -196,7 +196,7 @@ class Client(object):
 
     def GET(self, url, **kwargs):
         """
-        wrap requests.get to allow:
+        wrap requests.get (also post and head, below) to allow:
           * injection of e.g. UserAgent header in one place rather than all over
           * hides requests itself to allow for change (unlikely) or use of Session
           # paves the way to inject the verify option, required to use pebble
@@ -205,15 +205,14 @@ class Client(object):
         return self._request("GET", url, **kwargs)
 
     def POST(self, url, **kwargs):
-        """
-        wrap requests.post for all the reasons listed for GET
-        """
-
         return self._request("POST", url, **kwargs)
+
+    def HEAD(self, url, **kwargs):
+        return self._request("HEAD", url, **kwargs)
 
     def _request(self, method, url, **kwargs):
         """
-        shared implementation for GET and POST
+        shared implementation for GET, HEAD and POST
         """
 
         # if there's no UserAgent header in args, inject it
@@ -225,7 +224,8 @@ class Client(object):
         if "timeout" not in kwargs:
             kwargs["timeout"] = self.ACME_REQUEST_TIMEOUT
 
-        return requests.request(method, url, **kwargs)
+        response = requests.request(method, url, **kwargs)
+        return response
 
     @staticmethod
     def log_response(response):
@@ -618,7 +618,7 @@ class Client(object):
         in order to protect against replay attacks.
         """
         self.logger.debug("get_nonce")
-        response = self.GET(self.ACME_GET_NONCE_URL)
+        response = self.HEAD(self.ACME_GET_NONCE_URL)
         nonce = response.headers["Replay-Nonce"]
         return nonce
 

--- a/sewer/client.py
+++ b/sewer/client.py
@@ -141,6 +141,7 @@ class Client(object):
         self.contact_email = contact_email
         self.bits = bits
         self.digest = digest
+        self.nonce = None
         self.ACME_REQUEST_TIMEOUT = ACME_REQUEST_TIMEOUT
         self.ACME_AUTH_STATUS_WAIT_PERIOD = ACME_AUTH_STATUS_WAIT_PERIOD
         self.ACME_AUTH_STATUS_MAX_CHECKS = ACME_AUTH_STATUS_MAX_CHECKS
@@ -225,6 +226,10 @@ class Client(object):
             kwargs["timeout"] = self.ACME_REQUEST_TIMEOUT
 
         response = requests.request(method, url, **kwargs)
+
+        # if this request had a fresh nonce, cherish it for later use
+        self.nonce = response.headers.get("Replay-Nonce", None)
+
         return response
 
     @staticmethod
@@ -613,14 +618,31 @@ class Client(object):
 
     def get_nonce(self):
         """
-        https://tools.ietf.org/html/draft-ietf-acme-acme#section-6.4
-        Each request to an ACME server must include a fresh unused nonce
-        in order to protect against replay attacks.
+        https://tools.ietf.org/html/rfc8555#page-14
+        §6.5 - In order to protect ACME resources from any possible replay attacks,
+        ACME POST requests have a mandatory anti-replay mechanism.  This mechanism
+        is based on the server maintaining a list of nonces that it has issued, and
+        requiring any signed request from the client to carry such a nonce.
+
+        The server MUST include a Replay-Nonce header field in every successful
+        response to a POST request and SHOULD provide it in error responses as well.
+
+        tl;dr: cherish those nonces, each one saves you a whole request-response!
         """
         self.logger.debug("get_nonce")
-        response = self.HEAD(self.ACME_GET_NONCE_URL)
-        nonce = response.headers["Replay-Nonce"]
-        return nonce
+
+        # if we don't have a cherished nonce, we have to fetch one
+        if not self.nonce:
+            response = self.HEAD(self.ACME_GET_NONCE_URL)
+            # tricky: fresh nonces are cherished in the _requests handler, so we
+            # don't have to extract it from the headers here.
+
+            ### FIX ME ### Handle error in request?  Never have, so it must be rare?
+
+        # return the cherished nonce and clear self.nonce since it's no longer unused
+        new_nonce = self.nonce
+        self.nonce = None
+        return new_nonce
 
     @staticmethod
     def stringfy_items(payload):

--- a/sewer/client.py
+++ b/sewer/client.py
@@ -194,6 +194,39 @@ class Client(object):
             self.logger.error("Unable to intialise client. error={0}".format(str(e)))
             raise e
 
+    def GET(self, url, **kwargs):
+        """
+        wrap requests.get to allow:
+          * injection of e.g. UserAgent header in one place rather than all over
+          * hides requests itself to allow for change (unlikely) or use of Session
+          # paves the way to inject the verify option, required to use pebble
+        """
+
+        return self._request("GET", url, **kwargs)
+
+    def POST(self, url, **kwargs):
+        """
+        wrap requests.post for all the reasons listed for GET
+        """
+
+        return self._request("POST", url, **kwargs)
+
+    def _request(self, method, url, **kwargs):
+        """
+        shared implementation for GET and POST
+        """
+
+        # if there's no UserAgent header in args, inject it
+        headers = kwargs.setdefault("headers", {})
+        if "UserAgent" not in headers:
+            headers["UserAgent"] = self.User_Agent
+
+        # add standard timeout if there's none already present
+        if "timeout" not in kwargs:
+            kwargs["timeout"] = self.ACME_REQUEST_TIMEOUT
+
+        return requests.request(method, url, **kwargs)
+
     @staticmethod
     def log_response(response):
         """
@@ -218,10 +251,7 @@ class Client(object):
 
     def get_acme_endpoints(self):
         self.logger.debug("get_acme_endpoints")
-        headers = {"User-Agent": self.User_Agent}
-        get_acme_endpoints = requests.get(
-            self.ACME_DIRECTORY_URL, timeout=self.ACME_REQUEST_TIMEOUT, headers=headers
-        )
+        get_acme_endpoints = self.GET(self.ACME_DIRECTORY_URL)
         self.logger.debug(
             "get_acme_endpoints_response. status_code={0}".format(get_acme_endpoints.status_code)
         )
@@ -389,10 +419,7 @@ class Client(object):
         This is also where we get the challenges/tokens.
         """
         self.logger.info("get_identifier_authorization")
-        headers = {"User-Agent": self.User_Agent}
-        get_identifier_authorization_response = requests.get(
-            url, timeout=self.ACME_REQUEST_TIMEOUT, headers=headers
-        )
+        get_identifier_authorization_response = self.GET(url)
         self.logger.debug(
             "get_identifier_authorization_response. status_code={0}. response={1}".format(
                 get_identifier_authorization_response.status_code,
@@ -466,10 +493,7 @@ class Client(object):
         number_of_checks = 0
         while True:
             time.sleep(self.ACME_AUTH_STATUS_WAIT_PERIOD)
-            headers = {"User-Agent": self.User_Agent}
-            check_authorization_status_response = requests.get(
-                authorization_url, timeout=self.ACME_REQUEST_TIMEOUT, headers=headers
-            )
+            check_authorization_status_response = self.GET(authorization_url)
             authorization_status = check_authorization_status_response.json()["status"]
             number_of_checks = number_of_checks + 1
             self.logger.debug(
@@ -594,10 +618,7 @@ class Client(object):
         in order to protect against replay attacks.
         """
         self.logger.debug("get_nonce")
-        headers = {"User-Agent": self.User_Agent}
-        response = requests.get(
-            self.ACME_GET_NONCE_URL, timeout=self.ACME_REQUEST_TIMEOUT, headers=headers
-        )
+        response = self.GET(self.ACME_GET_NONCE_URL)
         nonce = response.headers["Replay-Nonce"]
         return nonce
 
@@ -666,11 +687,11 @@ class Client(object):
 
     def make_signed_acme_request(self, url, payload):
         self.logger.debug("make_signed_acme_request")
-        headers = {"User-Agent": self.User_Agent}
+        headers = {}
         payload = self.stringfy_items(payload)
 
         if payload in ["GET_Z_CHALLENGE", "DOWNLOAD_Z_CERTIFICATE"]:
-            response = requests.get(url, timeout=self.ACME_REQUEST_TIMEOUT, headers=headers)
+            response = self.GET(url, headers=headers)
         else:
             payload64 = self.calculate_safe_base64(json.dumps(payload))
             protected = self.get_acme_header(url)
@@ -681,8 +702,8 @@ class Client(object):
                 {"protected": protected64, "payload": payload64, "signature": signature64}
             )
             headers.update({"Content-Type": "application/jose+json"})
-            response = requests.post(
-                url, data=data.encode("utf8"), timeout=self.ACME_REQUEST_TIMEOUT, headers=headers
+            response = self.POST(
+                url, data=data.encode("utf8"), headers=headers
             )
         return response
 

--- a/sewer/client.py
+++ b/sewer/client.py
@@ -632,7 +632,11 @@ class Client(object):
         self.logger.debug("get_nonce")
 
         if not self.cached_nonce:
-            self.HEAD(self.ACME_GET_NONCE_URL)
+
+            ### FIX ME ### RFC says this should be HEAD, but GET has always worked
+            ### KLUGE  ### switch back to HEAD after testing mocks aren't a problem
+
+            self.GET(self.ACME_GET_NONCE_URL)
             # tricky: the nonce will have been cached before HEAD returns
 
             ### FIX ME ### Handle error in request?  Never have, so it must be rare?

--- a/sewer/tests/test_Client.py
+++ b/sewer/tests/test_Client.py
@@ -26,8 +26,8 @@ class TestClient(TestCase):
 
     def setUp(self):
         self.domain_name = "example.com"
-        with mock.patch("requests.post") as mock_requests_post, mock.patch(
-            "requests.get"
+        with mock.patch("sewer.Client.POST") as mock_requests_post, mock.patch(
+            "sewer.Client.GET"
         ) as mock_requests_get:
             mock_requests_post.return_value = test_utils.MockResponse()
             mock_requests_get.return_value = test_utils.MockResponse()
@@ -45,8 +45,8 @@ class TestClient(TestCase):
         pass
 
     def test_get_get_acme_endpoints_failure_results_in_exception(self):
-        with mock.patch("requests.post") as mock_requests_post, mock.patch(
-            "requests.get"
+        with mock.patch("sewer.Client.POST") as mock_requests_post, mock.patch(
+            "sewer.Client.GET"
         ) as mock_requests_get:
             mock_requests_post.return_value = test_utils.MockResponse(status_code=409)
             mock_requests_get.return_value = test_utils.MockResponse(status_code=409)
@@ -64,8 +64,8 @@ class TestClient(TestCase):
             self.assertIn("Error while getting Acme endpoints", str(raised_exception.exception))
 
     def test_user_agent_is_generated(self):
-        with mock.patch("requests.post") as mock_requests_post, mock.patch(
-            "requests.get"
+        with mock.patch("sewer.Client.POST") as mock_requests_post, mock.patch(
+            "sewer.Client.GET"
         ) as mock_requests_get:
             mock_requests_post.return_value = test_utils.MockResponse()
             mock_requests_get.return_value = test_utils.MockResponse()
@@ -74,8 +74,8 @@ class TestClient(TestCase):
                 self.assertIn(i, self.client.User_Agent)
 
     def test_certificate_key_is_generated(self):
-        with mock.patch("requests.post") as mock_requests_post, mock.patch(
-            "requests.get"
+        with mock.patch("sewer.Client.POST") as mock_requests_post, mock.patch(
+            "sewer.Client.GET"
         ) as mock_requests_get:
             mock_requests_post.return_value = test_utils.MockResponse()
             mock_requests_get.return_value = test_utils.MockResponse()
@@ -91,8 +91,8 @@ class TestClient(TestCase):
             )
 
     def test_account_key_is_generated(self):
-        with mock.patch("requests.post") as mock_requests_post, mock.patch(
-            "requests.get"
+        with mock.patch("sewer.Client.POST") as mock_requests_post, mock.patch(
+            "sewer.Client.GET"
         ) as mock_requests_get:
             mock_requests_post.return_value = test_utils.MockResponse()
             mock_requests_get.return_value = test_utils.MockResponse()
@@ -108,8 +108,8 @@ class TestClient(TestCase):
             )
 
     def test_acme_registration_is_done(self):
-        with mock.patch("requests.post") as mock_requests_post, mock.patch(
-            "requests.get"
+        with mock.patch("sewer.Client.POST") as mock_requests_post, mock.patch(
+            "sewer.Client.GET"
         ) as mock_requests_get, mock.patch("sewer.Client.acme_register") as mock_acme_registration:
             mock_requests_post.return_value = test_utils.MockResponse()
             mock_requests_get.return_value = test_utils.MockResponse()
@@ -117,8 +117,8 @@ class TestClient(TestCase):
             self.assertTrue(mock_acme_registration.called)
 
     def test_acme_registration_failure_doesnt_result_in_certificate(self):
-        with mock.patch("requests.post") as mock_requests_post, mock.patch(
-            "requests.get"
+        with mock.patch("sewer.Client.POST") as mock_requests_post, mock.patch(
+            "sewer.Client.GET"
         ) as mock_requests_get:
             mock_requests_post.return_value = test_utils.MockResponse(status_code=400)
             mock_requests_get.return_value = test_utils.MockResponse(status_code=400)
@@ -132,8 +132,8 @@ class TestClient(TestCase):
             self.assertIn("Error while registering", str(raised_exception.exception))
 
     def test_get_identifier_authorization_is_called(self):
-        with mock.patch("requests.post") as mock_requests_post, mock.patch(
-            "requests.get"
+        with mock.patch("sewer.Client.POST") as mock_requests_post, mock.patch(
+            "sewer.Client.GET"
         ) as mock_requests_get, mock.patch(
             "sewer.Client.get_identifier_authorization"
         ) as mock_get_identifier_authorization:
@@ -150,8 +150,8 @@ class TestClient(TestCase):
             self.assertTrue(mock_get_identifier_authorization.called)
 
     def test_get_identifier_authorization_is_not_called(self):
-        with mock.patch("requests.post") as mock_requests_post, mock.patch(
-            "requests.get"
+        with mock.patch("sewer.Client.POST") as mock_requests_post, mock.patch(
+            "sewer.Client.GET"
         ) as mock_requests_get, mock.patch("sewer.Client.acme_register") as mock_acme_register:
             mock_requests_post.return_value = test_utils.MockResponse(status_code=400)
             mock_requests_get.return_value = test_utils.MockResponse(status_code=400)
@@ -168,8 +168,8 @@ class TestClient(TestCase):
             )
 
     def test_create_dns_record_is_called(self):
-        with mock.patch("requests.post") as mock_requests_post, mock.patch(
-            "requests.get"
+        with mock.patch("sewer.Client.POST") as mock_requests_post, mock.patch(
+            "sewer.Client.GET"
         ) as mock_requests_get, mock.patch(
             "sewer.tests.test_utils.ExmpleDnsProvider.create_dns_record"
         ) as mock_create_dns_record:
@@ -185,8 +185,8 @@ class TestClient(TestCase):
         valid_status_mock = mock.Mock()
         valid_status_mock.json.return_value = {"status": "valid"}
 
-        with mock.patch("requests.post") as mock_requests_post, mock.patch(
-            "requests.get"
+        with mock.patch("sewer.Client.POST") as mock_requests_post, mock.patch(
+            "sewer.Client.GET"
         ) as mock_requests_get, mock.patch(
             "sewer.Client.respond_to_challenge"
         ) as mock_respond_to_challenge, mock.patch(
@@ -204,8 +204,8 @@ class TestClient(TestCase):
             self.assertTrue(mock_respond_to_challenge.called)
 
     def test_check_authorization_status_is_called(self):
-        with mock.patch("requests.post") as mock_requests_post, mock.patch(
-            "requests.get"
+        with mock.patch("sewer.Client.POST") as mock_requests_post, mock.patch(
+            "sewer.Client.GET"
         ) as mock_requests_get, mock.patch(
             "sewer.Client.check_authorization_status"
         ) as mock_check_authorization_status:
@@ -215,8 +215,8 @@ class TestClient(TestCase):
             self.assertTrue(mock_check_authorization_status.called)
 
     def test_delete_dns_record_is_called(self):
-        with mock.patch("requests.post") as mock_requests_post, mock.patch(
-            "requests.get"
+        with mock.patch("sewer.Client.POST") as mock_requests_post, mock.patch(
+            "sewer.Client.GET"
         ) as mock_requests_get, mock.patch(
             "sewer.tests.test_utils.ExmpleDnsProvider.delete_dns_record"
         ) as mock_delete_dns_record:
@@ -226,8 +226,8 @@ class TestClient(TestCase):
             self.assertTrue(mock_delete_dns_record.called)
 
     def test_get_certificate_is_called(self):
-        with mock.patch("requests.post") as mock_requests_post, mock.patch(
-            "requests.get"
+        with mock.patch("sewer.Client.POST") as mock_requests_post, mock.patch(
+            "sewer.Client.GET"
         ) as mock_requests_get, mock.patch("sewer.Client.get_certificate") as mock_get_certificate:
             mock_requests_post.return_value = test_utils.MockResponse()
             mock_requests_get.return_value = test_utils.MockResponse()
@@ -235,8 +235,8 @@ class TestClient(TestCase):
             self.assertTrue(mock_get_certificate.called)
 
     def test_certificate_is_issued(self):
-        with mock.patch("requests.post") as mock_requests_post, mock.patch(
-            "requests.get"
+        with mock.patch("sewer.Client.POST") as mock_requests_post, mock.patch(
+            "sewer.Client.GET"
         ) as mock_requests_get:
             mock_requests_post.return_value = test_utils.MockResponse()
             mock_requests_get.return_value = test_utils.MockResponse()
@@ -244,8 +244,8 @@ class TestClient(TestCase):
                 self.assertIn(i, self.client.cert())
 
     def test_certificate_is_not_issued(self):
-        with mock.patch("requests.post") as mock_requests_post, mock.patch(
-            "requests.get"
+        with mock.patch("sewer.Client.POST") as mock_requests_post, mock.patch(
+            "sewer.Client.GET"
         ) as mock_requests_get, mock.patch(
             "sewer.Client.get_identifier_authorization"
         ) as mock_get_identifier_authorization, mock.patch(
@@ -272,8 +272,8 @@ class TestClient(TestCase):
             self.assertIn("Error applying for certificate", str(raised_exception.exception))
 
     def test_certificate_is_issued_for_renewal(self):
-        with mock.patch("requests.post") as mock_requests_post, mock.patch(
-            "requests.get"
+        with mock.patch("sewer.Client.POST") as mock_requests_post, mock.patch(
+            "sewer.Client.GET"
         ) as mock_requests_get:
             mock_requests_post.return_value = test_utils.MockResponse()
             mock_requests_get.return_value = test_utils.MockResponse()
@@ -310,8 +310,8 @@ class TestClientForSAN(TestClient):
             "staging.exampleSAN.com",
             "www.exampleSAN.com",
         ]
-        with mock.patch("requests.post") as mock_requests_post, mock.patch(
-            "requests.get"
+        with mock.patch("sewer.Client.POST") as mock_requests_post, mock.patch(
+            "sewer.Client.GET"
         ) as mock_requests_get:
             mock_requests_post.return_value = test_utils.MockResponse()
             mock_requests_get.return_value = test_utils.MockResponse()
@@ -340,8 +340,8 @@ class TestClientForWildcard(TestClient):
             "staging.exampleSAN.com",
             "www.exampleSAN.com",
         ]
-        with mock.patch("requests.post") as mock_requests_post, mock.patch(
-            "requests.get"
+        with mock.patch("sewer.Client.POST") as mock_requests_post, mock.patch(
+            "sewer.Client.GET"
         ) as mock_requests_get:
             mock_requests_post.return_value = test_utils.MockResponse()
             mock_requests_get.return_value = test_utils.MockResponse()


### PR DESCRIPTION
Fixes #143 by adding a simple fresh nonce cache that is refilled opportunistically from Replay-Nonce header included in most server responses.

NB: this builds on top of wrap-requests and requires that PR.

[to clarify: this branch will bring along the "wrap requests" work, because that's how git works.  I called it out separately when it was first submitted because the "wrap requests" code had been an earlier PR, and the nonce harvesting wasn't the original goal.]