### PR TITLE
Fix authorization status checker to check the last request before StopIteration

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,3 +23,4 @@ Contributors
 9. [@etienne-napoleone](https://github.com/etienne-napoleone)
 10. [@soloradish](https://github.com/soloradish)
 11. [Moritz Ulmer](https://www.protohaus.org)
+12. [rozgonik](https://github.com/rozgonik)

--- a/sewer/client.py
+++ b/sewer/client.py
@@ -489,7 +489,6 @@ class Client(object):
                     )
                 )
 
-
         self.logger.info("check_authorization_status_success")
         return check_authorization_status_response
 

--- a/sewer/client.py
+++ b/sewer/client.py
@@ -478,6 +478,8 @@ class Client(object):
                     self.log_response(check_authorization_status_response),
                 )
             )
+            if authorization_status in desired_status:
+                break
             if number_of_checks == self.ACME_AUTH_STATUS_MAX_CHECKS:
                 raise StopIteration(
                     "Checks done={0}. Max checks allowed={1}. Interval between checks={2}seconds.".format(
@@ -487,8 +489,6 @@ class Client(object):
                     )
                 )
 
-            if authorization_status in desired_status:
-                break
 
         self.logger.info("check_authorization_status_success")
         return check_authorization_status_response


### PR DESCRIPTION
Thank you for contributing to sewer.                    
Every contribution to sewer is important to us.                       
You may not know it, but you have just contributed to making the world a more safer and secure place.                         

## What(What have you changed?)
Changed the order of checks.

## Why(Why did you change it?)
Found a bug where the last GET response was not evaluated (but logged) before raising a StopIteration exception. Although the last response had a "valid" status, sewer still raised the exception.

This way the while loop does not terminate prematurely before checking the last request's status.
