### PR TITLE
Refactor the loop in check_authorization_status

### DIFF
--- a/sewer/client.py
+++ b/sewer/client.py
@@ -463,15 +463,13 @@ class Client(object):
         """
         self.logger.info("check_authorization_status")
         desired_status = desired_status or ["pending", "valid"]
-        number_of_checks = 0
-        while True:
+        for _ in range(self.ACME_AUTH_STATUS_MAX_CHECKS):
             time.sleep(self.ACME_AUTH_STATUS_WAIT_PERIOD)
             headers = {"User-Agent": self.User_Agent}
             check_authorization_status_response = requests.get(
                 authorization_url, timeout=self.ACME_REQUEST_TIMEOUT, headers=headers
             )
             authorization_status = check_authorization_status_response.json()["status"]
-            number_of_checks = number_of_checks + 1
             self.logger.debug(
                 "check_authorization_status_response. status_code={0}. response={1}".format(
                     check_authorization_status_response.status_code,
@@ -480,14 +478,12 @@ class Client(object):
             )
             if authorization_status in desired_status:
                 break
-            if number_of_checks == self.ACME_AUTH_STATUS_MAX_CHECKS:
-                raise StopIteration(
-                    "Checks done={0}. Max checks allowed={1}. Interval between checks={2}seconds.".format(
-                        number_of_checks,
-                        self.ACME_AUTH_STATUS_MAX_CHECKS,
-                        self.ACME_AUTH_STATUS_WAIT_PERIOD,
-                    )
+        else:
+            raise StopIteration(
+                "Checks done={0}. Max checks allowed={0}. Interval between checks={1}seconds.".format(
+                    self.ACME_AUTH_STATUS_MAX_CHECKS, self.ACME_AUTH_STATUS_WAIT_PERIOD
                 )
+            )
 
         self.logger.info("check_authorization_status_success")
         return check_authorization_status_response


### PR DESCRIPTION
## What have you changed?
Changed the while loop with an implicit counter to an explicit for cycle.
Also the "Checks done" and the "Max checks allowed" counter in the StopIteration exception makes no sense, because the two values will be the same (and equal to ACME_AUTH_STATUS_MAX_CHECKS) every time the exception kicks in.
I do not want to fiddle with the exception message, so made the counters reference the same value.

## Why did you change it?
@mmaney suggested the refactoring of this method's cycle at #148 in [his comment](https://github.com/komuw/sewer/pull/148#issuecomment-598526290).

Further refactoring can be done in the following way:
```
for [...]
    [...]
    if authorization_status in desired_status:
        self.logger.info("check_authorization_status_success")
        return check_authorization_status_response
raise StopIteration(
    "Checks done={0}. Max checks allowed={0}. Interval between checks={1}seconds.".format(
        self.ACME_AUTH_STATUS_MAX_CHECKS,
        self.ACME_AUTH_STATUS_WAIT_PERIOD,
    )
)
```
However it breaks the convention of ending the method with a logger call and a return statement.
To be consistent I opted to implement a variant with less changes.

(When submitting the original PR I had difficulties finding time for doing a proper refactor, that's why #148 was a quick-n-dirty fix.)

Update:
Sorry for the noise about the force-pushes.
(FYI: `black==18.9b0` and the latest `black==19.10b0` has different rulesets about trailing commas.)