### PR TITLE
Use unittest.mock in place of external module.  Requires Python 3.3+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
     # $ pip3 install -e .[dev,test]
     extras_require={
         "dev": ["coverage", "pypandoc", "twine", "wheel"],
-        "test": ["mock", "pylint==2.3.1", "black==18.9b0"],
+        "test": ["pylint==2.3.1", "black==18.9b0"],
         "cloudflare": dns_provider_deps_map["cloudflare"],
         "aliyun": dns_provider_deps_map["aliyun"],
         "hurricane": dns_provider_deps_map["hurricane"],

--- a/sewer/dns_providers/tests/test_acmedns.py
+++ b/sewer/dns_providers/tests/test_acmedns.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import json
 from unittest import TestCase
 

--- a/sewer/dns_providers/tests/test_aliyundns.py
+++ b/sewer/dns_providers/tests/test_aliyundns.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from unittest import TestCase
 import sewer
 from . import test_utils

--- a/sewer/dns_providers/tests/test_aurora.py
+++ b/sewer/dns_providers/tests/test_aurora.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from unittest import TestCase
 
 import sewer

--- a/sewer/dns_providers/tests/test_cloudflare.py
+++ b/sewer/dns_providers/tests/test_cloudflare.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import json
 from unittest import TestCase
 

--- a/sewer/dns_providers/tests/test_cloudns.py
+++ b/sewer/dns_providers/tests/test_cloudns.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from os import environ
 from unittest import TestCase
 

--- a/sewer/dns_providers/tests/test_dnspod.py
+++ b/sewer/dns_providers/tests/test_dnspod.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from unittest import TestCase
 
 import sewer

--- a/sewer/dns_providers/tests/test_duckdns.py
+++ b/sewer/dns_providers/tests/test_duckdns.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import json
 from unittest import TestCase
 

--- a/sewer/dns_providers/tests/test_hedns.py
+++ b/sewer/dns_providers/tests/test_hedns.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from unittest import TestCase
 import sewer
 from . import test_utils

--- a/sewer/dns_providers/tests/test_rackspace.py
+++ b/sewer/dns_providers/tests/test_rackspace.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from unittest import TestCase
 
 import sewer

--- a/sewer/dns_providers/tests/test_route53.py
+++ b/sewer/dns_providers/tests/test_route53.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from unittest import TestCase
 
 import sewer

--- a/sewer/tests/test_Client.py
+++ b/sewer/tests/test_Client.py
@@ -2,7 +2,7 @@
 # not to pollute the global namespace.
 # see: https://python-packaging.readthedocs.io/en/latest/testing.html
 
-import mock
+from unittest import mock
 import cryptography
 from unittest import TestCase
 


### PR DESCRIPTION
Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to sewer, and sewer agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that sewer shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.

See bug #151  
