### PR TITLE
Trivial: add unittest.mock change to powerdns driver

### DIFF
--- a/sewer/dns_providers/tests/test_powerdns.py
+++ b/sewer/dns_providers/tests/test_powerdns.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from unittest import TestCase
 import sewer
 


### PR DESCRIPTION
Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to sewer, and sewer agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that sewer shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.

## What and Why

Added unittest.mock change to test_powerdns.py in order to fix CI failure.
