### PR TITLE
Various cleanups - common auth code moved back into client.py; safe_b…

### DIFF
--- a/sewer/auth.py
+++ b/sewer/auth.py
@@ -1,16 +1,4 @@
 import logging
-import base64
-
-
-def calculate_safe_base64(un_encoded_data):
-    """
-    takes in a string or bytes
-    returns a string
-    """
-    if isinstance(un_encoded_data, str):
-        un_encoded_data = un_encoded_data.encode("utf8")
-    r = base64.urlsafe_b64encode(un_encoded_data).rstrip(b"=")
-    return r.decode("utf8")
 
 
 class BaseAuthProvider(object):
@@ -37,29 +25,6 @@ class BaseAuthProvider(object):
         except ValueError:
             log_body = response.content
         return log_body
-
-    def get_identifier_auth(self, authorization_response, url):
-        """
-        grab the identifier authorization info for the implimented auth challenge type
-        """
-        domain = authorization_response["identifier"]["value"]
-        wildcard = authorization_response.get("wildcard")
-        if wildcard:
-            domain = "*." + domain
-
-        for i in authorization_response["challenges"]:
-            if i["type"] == self.auth_type:
-                challenge = i
-                challenge_token = challenge["token"]
-                challenge_url = challenge["url"]
-
-                return {
-                    "domain": domain,
-                    "url": url,
-                    "wildcard": wildcard,
-                    "token": challenge_token,
-                    "challenge_url": challenge_url,
-                }
 
     def fulfill_authorization(self, identifier_auth, token, acme_keyauthorization):
         """

--- a/sewer/client.py
+++ b/sewer/client.py
@@ -445,13 +445,13 @@ class Client(object):
         response = self.GET(url)
         self.logger.debug(
             "get_identifier_authorization_response. status_code={0}. response={1}".format(
-                response.status_code, self.log_response(response),
+                response.status_code, self.log_response(response)
             )
         )
         if response.status_code not in [200, 201]:
             raise ValueError(
                 "Error getting identifier authorization: status_code={status_code} response={response}".format(
-                    status_code=response.status_code, response=self.log_response(response),
+                    status_code=response.status_code, response=self.log_response(response)
                 )
             )
         response_json = response.json()
@@ -466,7 +466,7 @@ class Client(object):
                 challenge_token = challenge["token"]
                 challenge_url = challenge["url"]
 
-                identifier_auth =  {
+                identifier_auth = {
                     "domain": domain,
                     "url": url,
                     "wildcard": wildcard,
@@ -485,9 +485,7 @@ class Client(object):
         acme_header_jwk_json = json.dumps(
             self.get_acme_header("GET_THUMBPRINT")["jwk"], sort_keys=True, separators=(",", ":")
         )
-        acme_thumbprint = safe_base64(
-            sha256(acme_header_jwk_json.encode("utf8")).digest()
-        )
+        acme_thumbprint = safe_base64(sha256(acme_header_jwk_json.encode("utf8")).digest())
         acme_keyauthorization = "{0}.{1}".format(token, acme_thumbprint)
 
         return acme_keyauthorization

--- a/sewer/client.py
+++ b/sewer/client.py
@@ -1,7 +1,7 @@
 import time
 import copy
 import json
-import hashlib
+from hashlib import sha256
 import logging
 import binascii
 import platform
@@ -12,7 +12,7 @@ import cryptography
 
 from . import __version__ as sewer_version
 from .config import ACME_DIRECTORY_URL_PRODUCTION
-from .auth import calculate_safe_base64
+from .lib import safe_base64
 
 
 class Client(object):
@@ -442,22 +442,38 @@ class Client(object):
         This is also where we get the challenges/tokens.
         """
         self.logger.info("get_identifier_authorization")
-        get_identifier_authorization_response = self.GET(url)
+        response = self.GET(url)
         self.logger.debug(
             "get_identifier_authorization_response. status_code={0}. response={1}".format(
-                get_identifier_authorization_response.status_code,
-                self.log_response(get_identifier_authorization_response),
+                response.status_code, self.log_response(response),
             )
         )
-        if get_identifier_authorization_response.status_code not in [200, 201]:
+        if response.status_code not in [200, 201]:
             raise ValueError(
                 "Error getting identifier authorization: status_code={status_code} response={response}".format(
-                    status_code=get_identifier_authorization_response.status_code,
-                    response=self.log_response(get_identifier_authorization_response),
+                    status_code=response.status_code, response=self.log_response(response),
                 )
             )
-        authorization_response = get_identifier_authorization_response.json()
-        identifier_auth = self.auth_provider.get_identifier_auth(authorization_response, url)
+        response_json = response.json()
+        domain = response_json["identifier"]["value"]
+        wildcard = response_json.get("wildcard")
+        if wildcard:
+            domain = "*." + domain
+
+        for i in response_json["challenges"]:
+            if i["type"] == self.auth_provider.auth_type:
+                challenge = i
+                challenge_token = challenge["token"]
+                challenge_url = challenge["url"]
+
+                identifier_auth =  {
+                    "domain": domain,
+                    "url": url,
+                    "wildcard": wildcard,
+                    "token": challenge_token,
+                    "challenge_url": challenge_url,
+                }
+
         self.logger.debug(
             "get_identifier_authorization_success. identifier_auth={0}".format(identifier_auth)
         )
@@ -469,8 +485,8 @@ class Client(object):
         acme_header_jwk_json = json.dumps(
             self.get_acme_header("GET_THUMBPRINT")["jwk"], sort_keys=True, separators=(",", ":")
         )
-        acme_thumbprint = calculate_safe_base64(
-            hashlib.sha256(acme_header_jwk_json.encode("utf8")).digest()
+        acme_thumbprint = safe_base64(
+            sha256(acme_header_jwk_json.encode("utf8")).digest()
         )
         acme_keyauthorization = "{0}.{1}".format(token, acme_thumbprint)
 
@@ -561,7 +577,7 @@ class Client(object):
         GET request to the order resource to obtain its current state.
         """
         self.logger.info("send_csr")
-        payload = {"csr": calculate_safe_base64(self.csr)}
+        payload = {"csr": safe_base64(self.csr)}
         send_csr_response = self.make_signed_acme_request(url=finalize_url, payload=payload)
         self.logger.debug(
             "send_csr_response. status_code={0}. response={1}".format(
@@ -668,8 +684,8 @@ class Client(object):
             modulus = "{0:x}".format(public_key_public_numbers.n)
             jwk = {
                 "kty": "RSA",
-                "e": calculate_safe_base64(binascii.unhexlify(exponent)),
-                "n": calculate_safe_base64(binascii.unhexlify(modulus)),
+                "e": safe_base64(binascii.unhexlify(exponent)),
+                "n": safe_base64(binascii.unhexlify(modulus)),
             }
             header["jwk"] = jwk
         else:
@@ -684,11 +700,11 @@ class Client(object):
         if payload in ["GET_Z_CHALLENGE", "DOWNLOAD_Z_CERTIFICATE"]:
             response = self.GET(url, headers=headers)
         else:
-            payload64 = calculate_safe_base64(json.dumps(payload))
+            payload64 = safe_base64(json.dumps(payload))
             protected = self.get_acme_header(url)
-            protected64 = calculate_safe_base64(json.dumps(protected))
+            protected64 = safe_base64(json.dumps(protected))
             signature = self.sign_message(message="{0}.{1}".format(protected64, payload64))  # bytes
-            signature64 = calculate_safe_base64(signature)  # str
+            signature64 = safe_base64(signature)  # str
             data = json.dumps(
                 {"protected": protected64, "payload": payload64, "signature": signature64}
             )

--- a/sewer/dns_providers/common.py
+++ b/sewer/dns_providers/common.py
@@ -1,6 +1,7 @@
 from hashlib import sha256
 
-from sewer.auth import BaseAuthProvider, calculate_safe_base64
+from sewer.auth import BaseAuthProvider
+from sewer.lib import safe_base64
 
 
 class BaseDns(BaseAuthProvider):
@@ -71,7 +72,7 @@ class BaseDns(BaseAuthProvider):
         record:
         """
         domain_name = identifier_auth["domain"]
-        base64_of_acme_keyauthorization = calculate_safe_base64(
+        base64_of_acme_keyauthorization = safe_base64(
             sha256(acme_keyauthorization.encode("utf8")).digest()
         )
         self.create_dns_record(domain_name, base64_of_acme_keyauthorization)

--- a/sewer/dns_providers/common.py
+++ b/sewer/dns_providers/common.py
@@ -4,6 +4,12 @@ from sewer.auth import BaseAuthProvider
 from sewer.lib import safe_base64
 
 
+def dns_challenge(key_auth: str) -> str:
+    "return safe-base64 of hash of key_auth; used for dns response"
+
+    return safe_base64(sha256(key_auth.encode("utf8")).digest())
+
+
 class BaseDns(BaseAuthProvider):
     def __init__(self):
         super(BaseDns, self).__init__("dns-01")
@@ -72,11 +78,9 @@ class BaseDns(BaseAuthProvider):
         record:
         """
         domain_name = identifier_auth["domain"]
-        base64_of_acme_keyauthorization = safe_base64(
-            sha256(acme_keyauthorization.encode("utf8")).digest()
-        )
-        self.create_dns_record(domain_name, base64_of_acme_keyauthorization)
-        return {"domain_name": domain_name, "value": base64_of_acme_keyauthorization}
+        txt_value = dns_challenge(acme_keyauthorization)
+        self.create_dns_record(domain_name, txt_value)
+        return {"domain_name": domain_name, "value": txt_value}
 
-    def cleanup_authorization(self, domain_name, value):
-        self.delete_dns_record(domain_name, value)
+    def cleanup_authorization(self, **kwargs):
+        self.delete_dns_record(kwargs["domain_name"], kwargs["value"])

--- a/sewer/http_providers/common.py
+++ b/sewer/http_providers/common.py
@@ -44,5 +44,5 @@ class BaseHttp(BaseAuthProvider):
             "acme_keyauthorization": acme_keyauthorization,
         }
 
-    def cleanup_authorization(self, domain_name, token, **kwargs):
-        self.delete_challenge_file(domain_name, token)
+    def cleanup_authorization(self, **kwargs):
+        self.delete_challenge_file(kwargs["domain_name"], kwargs["token"])

--- a/sewer/lib.py
+++ b/sewer/lib.py
@@ -1,0 +1,12 @@
+import base64
+
+
+def safe_base64(un_encoded_data) -> str:
+    """
+    takes in a string or bytes
+    returns a string
+    """
+    if isinstance(un_encoded_data, str):
+        un_encoded_data = un_encoded_data.encode("utf8")
+    r = base64.urlsafe_b64encode(un_encoded_data).rstrip(b"=")
+    return r.decode("utf8")

--- a/sewer/lib.py
+++ b/sewer/lib.py
@@ -1,11 +1,10 @@
 import base64
+from typing import Union
 
 
-def safe_base64(un_encoded_data) -> str:
-    """
-    takes in a string or bytes
-    returns a string
-    """
+def safe_base64(un_encoded_data: Union[str, bytes]) -> str:
+    "return ACME-safe base64 encoding of un_encoded_data"
+
     if isinstance(un_encoded_data, str):
         un_encoded_data = un_encoded_data.encode("utf8")
     r = base64.urlsafe_b64encode(un_encoded_data).rstrip(b"=")


### PR DESCRIPTION
…ase64 in lib.py; ...

Corrected odd placement of a piece of ACME authorizations parsing.   After looking through the original tree's commits, I'm pretty sure this was a very early decision that was less than fully reconsidered later on (it was hoisted into auth.py, but I see no reason it can't go all the way back).

Approved entirely pulling @staticmethod calculate_safe_base64, but putting this into auth.py... no, that's off.  Could have gone back as a bare function in client, but since it is clearly needed outside of client...  lib.py, meh.  Maybe that should have been in sewer.__init__.py instead?

Oh, and calculate_* is just typographical noise, same as if each function was named function_x or method_y.  Except for very rare cases, of which safe_base64 is not one IMO.