### PR TITLE
FIX #162 - removed "*." added by client.py, removed often incomplete …

### DIFF
--- a/sewer/client.py
+++ b/sewer/client.py
@@ -457,8 +457,6 @@ class Client(object):
         response_json = response.json()
         domain = response_json["identifier"]["value"]
         wildcard = response_json.get("wildcard")
-        if wildcard:
-            domain = "*." + domain
 
         for i in response_json["challenges"]:
             if i["type"] == self.auth_provider.auth_type:

--- a/sewer/dns_providers/acmedns.py
+++ b/sewer/dns_providers/acmedns.py
@@ -35,8 +35,6 @@ class AcmeDnsDns(common.BaseDns):
 
     def create_dns_record(self, domain_name, domain_dns_value):
         self.logger.info("create_dns_record")
-        # if we have been given a wildcard name, strip wildcard
-        domain_name = domain_name.lstrip("*.")
 
         resolver = Resolver(configure=False)
         resolver.nameservers = ["8.8.8.8"]

--- a/sewer/dns_providers/aliyundns.py
+++ b/sewer/dns_providers/aliyundns.py
@@ -150,8 +150,6 @@ class AliyunDns(common.BaseDns):
         :param str domain_name: the value sewer client passed in, like *.menduo.example.com
         :return tuple: root, zone, acme_txt
         """
-        # if we have been given a wildcard name, strip wildcard
-        domain_name = domain_name.lstrip("*.")
         if domain_name.count(".") > 1:
             zone, middle, last = str(domain_name).rsplit(".", 2)
             root = ".".join([middle, last])

--- a/sewer/dns_providers/auroradns.py
+++ b/sewer/dns_providers/auroradns.py
@@ -33,8 +33,6 @@ class AuroraDns(common.BaseDns):
 
     def create_dns_record(self, domain_name, domain_dns_value):
         self.logger.info("create_dns_record")
-        # if we have been given a wildcard name, strip wildcard
-        domain_name = domain_name.lstrip("*.")
 
         extractedDomain = tldextract.extract(domain_name)
         domainSuffix = extractedDomain.domain + "." + extractedDomain.suffix

--- a/sewer/dns_providers/cloudflare.py
+++ b/sewer/dns_providers/cloudflare.py
@@ -74,8 +74,6 @@ class CloudFlareDns(common.BaseDns):
 
     def create_dns_record(self, domain_name, domain_dns_value):
         self.logger.info("create_dns_record")
-        # if we have been given a wildcard name, strip wildcard
-        domain_name = domain_name.lstrip("*.")
         self.find_dns_zone(domain_name)
 
         url = urllib.parse.urljoin(
@@ -110,8 +108,6 @@ class CloudFlareDns(common.BaseDns):
 
     def delete_dns_record(self, domain_name, domain_dns_value):
         self.logger.info("delete_dns_record")
-        # if we have been given a wildcard name, strip wildcard
-        domain_name = domain_name.lstrip("*.")
 
         class MockResponse(object):
             def __init__(self, status_code=200, content="mock-response"):

--- a/sewer/dns_providers/cloudns.py
+++ b/sewer/dns_providers/cloudns.py
@@ -7,6 +7,9 @@ except ImportError:
 from . import common
 
 
+### FIX ME ### this assumes there are only two levels above the host (no bbc.co.uk eg.)
+
+
 def _split_domain_name(domain_name):
     """ClouDNS requires the domain name and host to be split."""
     full_domain_name = "_acme-challenge.{}".format(domain_name)
@@ -14,9 +17,6 @@ def _split_domain_name(domain_name):
 
     domain_name = ".".join(domain_parts[-2:])
     host = ".".join(domain_parts[:-2])
-
-    if host == "_acme-challenge.*":
-        host = "_acme-challenge"
 
     return domain_name, host
 

--- a/sewer/dns_providers/dnspod.py
+++ b/sewer/dns_providers/dnspod.py
@@ -26,9 +26,10 @@ class DNSPodDns(common.BaseDns):
 
     def create_dns_record(self, domain_name, domain_dns_value):
         self.logger.info("create_dns_record")
-        # if we have been given a wildcard name, strip wildcard
-        domain_name = domain_name.lstrip("*.")
         subd = ""
+
+        ### FIX ME ### domain is exactly last two parts (no bbc.co.uk eg.)
+
         if domain_name.count(".") != 1:  # not top level domain
             pos = domain_name.rfind(".", 0, domain_name.rfind("."))
             subd = domain_name[:pos]
@@ -68,8 +69,10 @@ class DNSPodDns(common.BaseDns):
 
     def delete_dns_record(self, domain_name, domain_dns_value):
         self.logger.info("delete_dns_record")
-        domain_name = domain_name.lstrip("*.")
         subd = ""
+
+        ### FIX ME ### domain is exactly last two parts (no bbc.co.uk eg.)
+
         if domain_name.count(".") != 1:  # not top level domain
             pos = domain_name.rfind(".", 0, domain_name.rfind("."))
             subd = domain_name[:pos]

--- a/sewer/dns_providers/duckdns.py
+++ b/sewer/dns_providers/duckdns.py
@@ -21,8 +21,6 @@ class DuckDNSDns(common.BaseDns):
 
     def _common_dns_record(self, logger_info, domain_name, payload_end_arg):
         self.logger.info("{0}".format(logger_info))
-        # if we have been given a wildcard name, strip wildcard
-        domain_name = domain_name.lstrip("*.")
         # add provider domain to the domain name if not present
         provider_domain = ".duckdns.org"
         if domain_name.rfind(provider_domain) == -1:

--- a/sewer/dns_providers/hurricane.py
+++ b/sewer/dns_providers/hurricane.py
@@ -45,8 +45,6 @@ class HurricaneDns(common.BaseDns):
         :param str domain_name: the value sewer client passed in, like *.menduo.example.com
         :return tuple: root, zone, acme_txt
         """
-        # if we have been given a wildcard name, strip wildcard
-        domain_name = domain_name.lstrip("*.")
         if domain_name.count(".") > 1:
             zone, middle, last = str(domain_name).rsplit(".", 2)
             root = ".".join([middle, last])

--- a/sewer/dns_providers/rackspace.py
+++ b/sewer/dns_providers/rackspace.py
@@ -173,8 +173,6 @@ class RackspaceDns(common.BaseDns):
 
     def create_dns_record(self, domain_name, domain_dns_value):
         self.logger.info("create_dns_record")
-        # strip wildcard if present
-        domain_name = domain_name.lstrip("*.")
         self.RACKSPACE_DNS_ZONE_ID = self.find_dns_zone_id(domain_name)
         record_name = "_acme-challenge." + domain_name
         url = urllib.parse.urljoin(

--- a/sewer/dns_providers/tests/test_aliyundns.py
+++ b/sewer/dns_providers/tests/test_aliyundns.py
@@ -33,21 +33,8 @@ class TestAliyunDNS(TestCase):
         self.assertEqual(zone, _zone)
         self.assertEqual(acme_txt, "_acme-challenge.%s" % zone)
 
-        domain = "*.%s.%s" % (_zone, self.domain_name)
-        root, zone, acme_txt = self.dns_class.extract_zone(domain)
-
-        self.assertEqual(root, self.domain_name)
-        self.assertEqual(zone, _zone)
-        self.assertEqual(acme_txt, "_acme-challenge.%s" % zone)
-
     def test_extract_zone_root(self):
         domain = self.domain_name
-        root, zone, acme_txt = self.dns_class.extract_zone(domain)
-        self.assertEqual(root, self.domain_name)
-        self.assertEqual(zone, "")
-        self.assertEqual(acme_txt, "_acme-challenge")
-
-        domain = "*." + self.domain_name
         root, zone, acme_txt = self.dns_class.extract_zone(domain)
         self.assertEqual(root, self.domain_name)
         self.assertEqual(zone, "")

--- a/sewer/dns_providers/tests/test_hedns.py
+++ b/sewer/dns_providers/tests/test_hedns.py
@@ -35,21 +35,8 @@ class TestHEDNS(TestCase):
         self.assertEqual(zone, _zone)
         self.assertEqual(acme_txt, "_acme-challenge.%s" % zone)
 
-        domain = "*.%s.%s" % (_zone, self.domain_name)
-        root, zone, acme_txt = self.dns_class.extract_zone(domain)
-
-        self.assertEqual(root, self.domain_name)
-        self.assertEqual(zone, _zone)
-        self.assertEqual(acme_txt, "_acme-challenge.%s" % zone)
-
     def test_extract_zone_root(self):
         domain = self.domain_name
-        root, zone, acme_txt = self.dns_class.extract_zone(domain)
-        self.assertEqual(root, self.domain_name)
-        self.assertEqual(zone, "")
-        self.assertEqual(acme_txt, "_acme-challenge")
-
-        domain = "*." + self.domain_name
         root, zone, acme_txt = self.dns_class.extract_zone(domain)
         self.assertEqual(root, self.domain_name)
         self.assertEqual(zone, "")


### PR DESCRIPTION
…fixes from most providers.

Contributor offers to license certain software (a “Contribution” or multiple “Contributions”) to sewer, and sewer agrees to accept said Contributions, under the terms of the MIT License.
Contributor understands and agrees that sewer shall have the irrevocable and perpetual right to make and distribute copies of any Contribution, as well as to create and distribute collective works and derivative works of any Contribution, under the MIT License.

## What(What have you changed?)

Removed prepending of "*." to wildcard domains in `Client.get_identifier_authorization` to fix #162 as well as several other providers that appear to have the same problem but no open bug I can find.

## Why(Why did you change it?)

8 of 11 providers had the obvious `domain_name.lstrip("*')` patch, though several only apply that to adding domains, and so probably fail when deleting them (may not be checked & reported in the driver?).  One other achieved the same removal in a different way.  The two that didn't were rout53 (cause of the cited bug report) and powerdns, which is a fairly new driver and certainly looks like it would fail to handle "*.domain.tld".  Would love to hear from @kylejohnson about that one.
