### PR TITLE
maxChecks cli arg --> ACME_AUTH_STATUS_MAX_CHECKS

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ usage: sewer [-h] [--version] [--account_key ACCOUNT_KEY]
              [--bundle_name BUNDLE_NAME] [--endpoint {production,staging}]
              [--email EMAIL] --action {run,renew} [--out_dir OUT_DIR]
              [--loglevel {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
+             [--maxChecks ACME_AUTH_STATUS_MAX_CHECKS]
 
 Sewer is a Let's Encrypt(ACME) client.
 
@@ -223,6 +224,11 @@ optional arguments:
   --loglevel {DEBUG,INFO,WARNING,ERROR,CRITICAL}
                         The log level to output log messages at. eg:
                         --loglevel DEBUG
+                        
+  --maxChecks ACME_AUTH_STATUS_MAX_CHECKS
+                        The number of attempts sewer will make to verfiy that
+                        the DNS challenge has propegated. By default sewer will
+                        make this check every 8 seconds.
 ```
 
 The cerrtificate, certificate key and account key will be saved in the directory that you run sewer from.             

--- a/sewer/cli.py
+++ b/sewer/cli.py
@@ -147,6 +147,14 @@ def main():
         help="The log level to output log messages at. \
         eg: --loglevel DEBUG",
     )
+    parser.add_argument(
+        "--maxChecks",
+        type=int,
+        required=False,
+        default=3,
+        help="The number of times sewer will check the global DNS records to see if the challenge text is available \
+            eg: --maxChecks 10",
+    )
 
     args = parser.parse_args()
 
@@ -161,6 +169,7 @@ def main():
     email = args.email
     loglevel = args.loglevel
     out_dir = args.out_dir
+    maxChecks = args.maxChecks
 
     # Make sure the output dir user specified is writable
     if not os.access(out_dir, os.W_OK):
@@ -331,6 +340,7 @@ def main():
         certificate_key=certificate_key,
         ACME_DIRECTORY_URL=ACME_DIRECTORY_URL,
         LOG_LEVEL=loglevel,
+        ACME_AUTH_STATUS_MAX_CHECKS=maxChecks
     )
     certificate_key = client.certificate_key
     account_key = client.account_key


### PR DESCRIPTION
Thank you for contributing to sewer.                    
Every contribution to sewer is important to us.                       
You may not know it, but you have just contributed to making the world a more safer and secure place.                         

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to sewer, and sewer agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that sewer shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

## What(What have you changed?)

added a cli flag to set the number of attempts sewer makes to verfify the DNS challenge

## Why(Why did you change it?)

Because sewer was timing out when trying to verify the DNS challenge, and so I needed it to wait for longer
