### PR TITLE
Gandi DNS service

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ The currently supported DNS providers are:
 9. [ClouDNS](https://www.cloudns.net)
 10. [AWS rout353](https://aws.amazon.com/route53/)
 11. [PowerDNS](https://doc.powerdns.com/authoritative/http-api/index.html)
-12. [Bring your own dns provider](#bring-your-own-dns-provider)
+12. [Gandi](https://doc.livedns.gandi.net/)
+13. [Bring your own dns provider](#bring-your-own-dns-provider)
 
 ...
 

--- a/sewer/__init__.py
+++ b/sewer/__init__.py
@@ -12,4 +12,5 @@ from .dns_providers import DuckDNSDns  # noqa:F401
 from .dns_providers import ClouDNSDns  # noqa:F401
 from .dns_providers import Route53Dns  # noqa:F401
 from .dns_providers import PowerDNSDns  # noqa:F401
+from .dns_providers import GandiDns  # noqa:F401
 from .http_providers import BaseHttp  # noqa: F401

--- a/sewer/cli.py
+++ b/sewer/cli.py
@@ -73,6 +73,7 @@ def main():
             "duckdns",
             "cloudns",
             "powerdns",
+            "gandi"
         ],
         help="The name of the dns provider that you want to use.",
     )
@@ -315,6 +316,17 @@ def main():
             powerdns_api_url = os.environ["POWERDNS_API_URL"]
 
             dns_class = PowerDNSDns(powerdns_api_key, powerdns_api_url)
+            logger.info("chosen_dns_provider. Using {0} as dns provider.".format(dns_provider))
+        except KeyError as e:
+            logger.error("ERROR:: Please supply {0} as an environment variable.".format(str(e)))
+            raise
+    elif dns_provider == "gandi":
+        from . import GandiDns
+
+        try:
+            gandi_api_key = os.environ["GANDI_API_KEY"]
+
+            dns_class = GandiDns(GANDI_API_KEY=gandi_api_key)
             logger.info("chosen_dns_provider. Using {0} as dns provider.".format(dns_provider))
         except KeyError as e:
             logger.error("ERROR:: Please supply {0} as an environment variable.".format(str(e)))

--- a/sewer/cli.py
+++ b/sewer/cli.py
@@ -209,9 +209,7 @@ def main():
             logger.error(err)
             raise KeyError(err)
 
-        logger.info(
-            "chosen_dns_provider. Using {0} as dns provider.".format(dns_provider)
-        )
+        logger.info("chosen_dns_provider. Using {0} as dns provider.".format(dns_provider))
 
     elif dns_provider == "aurora":
         from . import AuroraDns
@@ -223,13 +221,9 @@ def main():
             dns_class = AuroraDns(
                 AURORA_API_KEY=AURORA_API_KEY, AURORA_SECRET_KEY=AURORA_SECRET_KEY
             )
-            logger.info(
-                "chosen_dns_provider. Using {0} as dns provider.".format(dns_provider)
-            )
+            logger.info("chosen_dns_provider. Using {0} as dns provider.".format(dns_provider))
         except KeyError as e:
-            logger.error(
-                "ERROR:: Please supply {0} as an environment variable.".format(str(e))
-            )
+            logger.error("ERROR:: Please supply {0} as an environment variable.".format(str(e)))
             raise
 
     elif dns_provider == "acmedns":
@@ -245,13 +239,9 @@ def main():
                 ACME_DNS_API_KEY=ACME_DNS_API_KEY,
                 ACME_DNS_API_BASE_URL=ACME_DNS_API_BASE_URL,
             )
-            logger.info(
-                "chosen_dns_provider. Using {0} as dns provider.".format(dns_provider)
-            )
+            logger.info("chosen_dns_provider. Using {0} as dns provider.".format(dns_provider))
         except KeyError as e:
-            logger.error(
-                "ERROR:: Please supply {0} as an environment variable.".format(str(e))
-            )
+            logger.error("ERROR:: Please supply {0} as an environment variable.".format(str(e)))
             raise
     elif dns_provider == "aliyun":
         from . import AliyunDns
@@ -261,13 +251,9 @@ def main():
             aliyun_secret = os.environ["ALIYUN_AK_SECRET"]
             aliyun_endpoint = os.environ.get("ALIYUN_ENDPOINT", "cn-beijing")
             dns_class = AliyunDns(aliyun_ak, aliyun_secret, aliyun_endpoint)
-            logger.info(
-                "chosen_dns_provider. Using {0} as dns provider.".format(dns_provider)
-            )
+            logger.info("chosen_dns_provider. Using {0} as dns provider.".format(dns_provider))
         except KeyError as e:
-            logger.error(
-                "ERROR:: Please supply {0} as an environment variable.".format(str(e))
-            )
+            logger.error("ERROR:: Please supply {0} as an environment variable.".format(str(e)))
             raise
     elif dns_provider == "hurricane":
         from . import HurricaneDns
@@ -276,13 +262,9 @@ def main():
             he_username = os.environ["HURRICANE_USERNAME"]
             he_password = os.environ["HURRICANE_PASSWORD"]
             dns_class = HurricaneDns(he_username, he_password)
-            logger.info(
-                "chosen_dns_provider. Using {0} as dns provider.".format(dns_provider)
-            )
+            logger.info("chosen_dns_provider. Using {0} as dns provider.".format(dns_provider))
         except KeyError as e:
-            logger.error(
-                "ERROR:: Please supply {0} as an environment variable.".format(str(e))
-            )
+            logger.error("ERROR:: Please supply {0} as an environment variable.".format(str(e)))
             raise
     elif dns_provider == "rackspace":
         from . import RackspaceDns
@@ -291,13 +273,9 @@ def main():
             RACKSPACE_USERNAME = os.environ["RACKSPACE_USERNAME"]
             RACKSPACE_API_KEY = os.environ["RACKSPACE_API_KEY"]
             dns_class = RackspaceDns(RACKSPACE_USERNAME, RACKSPACE_API_KEY)
-            logger.info(
-                "chosen_dns_prover. Using {0} as dns provider. ".format(dns_provider)
-            )
+            logger.info("chosen_dns_prover. Using {0} as dns provider. ".format(dns_provider))
         except KeyError as e:
-            logger.error(
-                "ERROR:: Please supply {0} as an environment variable.".format(str(e))
-            )
+            logger.error("ERROR:: Please supply {0} as an environment variable.".format(str(e)))
             raise
     elif dns_provider == "dnspod":
         from . import DNSPodDns
@@ -306,13 +284,9 @@ def main():
             DNSPOD_ID = os.environ["DNSPOD_ID"]
             DNSPOD_API_KEY = os.environ["DNSPOD_API_KEY"]
             dns_class = DNSPodDns(DNSPOD_ID, DNSPOD_API_KEY)
-            logger.info(
-                "chosen_dns_prover. Using {0} as dns provider. ".format(dns_provider)
-            )
+            logger.info("chosen_dns_prover. Using {0} as dns provider. ".format(dns_provider))
         except KeyError as e:
-            logger.error(
-                "ERROR:: Please supply {0} as an environment variable.".format(str(e))
-            )
+            logger.error("ERROR:: Please supply {0} as an environment variable.".format(str(e)))
             raise
     elif dns_provider == "duckdns":
         from . import DuckDNSDns
@@ -321,26 +295,18 @@ def main():
             duckdns_token = os.environ["DUCKDNS_TOKEN"]
 
             dns_class = DuckDNSDns(duckdns_token=duckdns_token)
-            logger.info(
-                "chosen_dns_provider. Using {0} as dns provider.".format(dns_provider)
-            )
+            logger.info("chosen_dns_provider. Using {0} as dns provider.".format(dns_provider))
         except KeyError as e:
-            logger.error(
-                "ERROR:: Please supply {0} as an environment variable.".format(str(e))
-            )
+            logger.error("ERROR:: Please supply {0} as an environment variable.".format(str(e)))
             raise
     elif dns_provider == "cloudns":
         from . import ClouDNSDns
 
         try:
             dns_class = ClouDNSDns()
-            logger.info(
-                "chosen_dns_provider. Using {0} as dns provider.".format(dns_provider)
-            )
+            logger.info("chosen_dns_provider. Using {0} as dns provider.".format(dns_provider))
         except KeyError as e:
-            logger.error(
-                "ERROR:: Please supply {0} as an environment variable.".format(str(e))
-            )
+            logger.error("ERROR:: Please supply {0} as an environment variable.".format(str(e)))
             raise
     elif dns_provider == "powerdns":
         from . import PowerDNSDns
@@ -350,13 +316,9 @@ def main():
             powerdns_api_url = os.environ["POWERDNS_API_URL"]
 
             dns_class = PowerDNSDns(powerdns_api_key, powerdns_api_url)
-            logger.info(
-                "chosen_dns_provider. Using {0} as dns provider.".format(dns_provider)
-            )
+            logger.info("chosen_dns_provider. Using {0} as dns provider.".format(dns_provider))
         except KeyError as e:
-            logger.error(
-                "ERROR:: Please supply {0} as an environment variable.".format(str(e))
-            )
+            logger.error("ERROR:: Please supply {0} as an environment variable.".format(str(e)))
             raise
     elif dns_provider == "gandi":
         from . import GandiDns
@@ -365,13 +327,9 @@ def main():
             gandi_api_key = os.environ["GANDI_API_KEY"]
 
             dns_class = GandiDns(GANDI_API_KEY=gandi_api_key)
-            logger.info(
-                "chosen_dns_provider. Using {0} as dns provider.".format(dns_provider)
-            )
+            logger.info("chosen_dns_provider. Using {0} as dns provider.".format(dns_provider))
         except KeyError as e:
-            logger.error(
-                "ERROR:: Please supply {0} as an environment variable.".format(str(e))
-            )
+            logger.error("ERROR:: Please supply {0} as an environment variable.".format(str(e)))
             raise
     else:
         raise ValueError("The dns provider {0} is not recognised.".format(dns_provider))

--- a/sewer/cli.py
+++ b/sewer/cli.py
@@ -73,7 +73,7 @@ def main():
             "duckdns",
             "cloudns",
             "powerdns",
-            "gandi"
+            "gandi",
         ],
         help="The name of the dns provider that you want to use.",
     )
@@ -209,7 +209,9 @@ def main():
             logger.error(err)
             raise KeyError(err)
 
-        logger.info("chosen_dns_provider. Using {0} as dns provider.".format(dns_provider))
+        logger.info(
+            "chosen_dns_provider. Using {0} as dns provider.".format(dns_provider)
+        )
 
     elif dns_provider == "aurora":
         from . import AuroraDns
@@ -221,9 +223,13 @@ def main():
             dns_class = AuroraDns(
                 AURORA_API_KEY=AURORA_API_KEY, AURORA_SECRET_KEY=AURORA_SECRET_KEY
             )
-            logger.info("chosen_dns_provider. Using {0} as dns provider.".format(dns_provider))
+            logger.info(
+                "chosen_dns_provider. Using {0} as dns provider.".format(dns_provider)
+            )
         except KeyError as e:
-            logger.error("ERROR:: Please supply {0} as an environment variable.".format(str(e)))
+            logger.error(
+                "ERROR:: Please supply {0} as an environment variable.".format(str(e))
+            )
             raise
 
     elif dns_provider == "acmedns":
@@ -239,9 +245,13 @@ def main():
                 ACME_DNS_API_KEY=ACME_DNS_API_KEY,
                 ACME_DNS_API_BASE_URL=ACME_DNS_API_BASE_URL,
             )
-            logger.info("chosen_dns_provider. Using {0} as dns provider.".format(dns_provider))
+            logger.info(
+                "chosen_dns_provider. Using {0} as dns provider.".format(dns_provider)
+            )
         except KeyError as e:
-            logger.error("ERROR:: Please supply {0} as an environment variable.".format(str(e)))
+            logger.error(
+                "ERROR:: Please supply {0} as an environment variable.".format(str(e))
+            )
             raise
     elif dns_provider == "aliyun":
         from . import AliyunDns
@@ -251,9 +261,13 @@ def main():
             aliyun_secret = os.environ["ALIYUN_AK_SECRET"]
             aliyun_endpoint = os.environ.get("ALIYUN_ENDPOINT", "cn-beijing")
             dns_class = AliyunDns(aliyun_ak, aliyun_secret, aliyun_endpoint)
-            logger.info("chosen_dns_provider. Using {0} as dns provider.".format(dns_provider))
+            logger.info(
+                "chosen_dns_provider. Using {0} as dns provider.".format(dns_provider)
+            )
         except KeyError as e:
-            logger.error("ERROR:: Please supply {0} as an environment variable.".format(str(e)))
+            logger.error(
+                "ERROR:: Please supply {0} as an environment variable.".format(str(e))
+            )
             raise
     elif dns_provider == "hurricane":
         from . import HurricaneDns
@@ -262,9 +276,13 @@ def main():
             he_username = os.environ["HURRICANE_USERNAME"]
             he_password = os.environ["HURRICANE_PASSWORD"]
             dns_class = HurricaneDns(he_username, he_password)
-            logger.info("chosen_dns_provider. Using {0} as dns provider.".format(dns_provider))
+            logger.info(
+                "chosen_dns_provider. Using {0} as dns provider.".format(dns_provider)
+            )
         except KeyError as e:
-            logger.error("ERROR:: Please supply {0} as an environment variable.".format(str(e)))
+            logger.error(
+                "ERROR:: Please supply {0} as an environment variable.".format(str(e))
+            )
             raise
     elif dns_provider == "rackspace":
         from . import RackspaceDns
@@ -273,9 +291,13 @@ def main():
             RACKSPACE_USERNAME = os.environ["RACKSPACE_USERNAME"]
             RACKSPACE_API_KEY = os.environ["RACKSPACE_API_KEY"]
             dns_class = RackspaceDns(RACKSPACE_USERNAME, RACKSPACE_API_KEY)
-            logger.info("chosen_dns_prover. Using {0} as dns provider. ".format(dns_provider))
+            logger.info(
+                "chosen_dns_prover. Using {0} as dns provider. ".format(dns_provider)
+            )
         except KeyError as e:
-            logger.error("ERROR:: Please supply {0} as an environment variable.".format(str(e)))
+            logger.error(
+                "ERROR:: Please supply {0} as an environment variable.".format(str(e))
+            )
             raise
     elif dns_provider == "dnspod":
         from . import DNSPodDns
@@ -284,9 +306,13 @@ def main():
             DNSPOD_ID = os.environ["DNSPOD_ID"]
             DNSPOD_API_KEY = os.environ["DNSPOD_API_KEY"]
             dns_class = DNSPodDns(DNSPOD_ID, DNSPOD_API_KEY)
-            logger.info("chosen_dns_prover. Using {0} as dns provider. ".format(dns_provider))
+            logger.info(
+                "chosen_dns_prover. Using {0} as dns provider. ".format(dns_provider)
+            )
         except KeyError as e:
-            logger.error("ERROR:: Please supply {0} as an environment variable.".format(str(e)))
+            logger.error(
+                "ERROR:: Please supply {0} as an environment variable.".format(str(e))
+            )
             raise
     elif dns_provider == "duckdns":
         from . import DuckDNSDns
@@ -295,18 +321,26 @@ def main():
             duckdns_token = os.environ["DUCKDNS_TOKEN"]
 
             dns_class = DuckDNSDns(duckdns_token=duckdns_token)
-            logger.info("chosen_dns_provider. Using {0} as dns provider.".format(dns_provider))
+            logger.info(
+                "chosen_dns_provider. Using {0} as dns provider.".format(dns_provider)
+            )
         except KeyError as e:
-            logger.error("ERROR:: Please supply {0} as an environment variable.".format(str(e)))
+            logger.error(
+                "ERROR:: Please supply {0} as an environment variable.".format(str(e))
+            )
             raise
     elif dns_provider == "cloudns":
         from . import ClouDNSDns
 
         try:
             dns_class = ClouDNSDns()
-            logger.info("chosen_dns_provider. Using {0} as dns provider.".format(dns_provider))
+            logger.info(
+                "chosen_dns_provider. Using {0} as dns provider.".format(dns_provider)
+            )
         except KeyError as e:
-            logger.error("ERROR:: Please supply {0} as an environment variable.".format(str(e)))
+            logger.error(
+                "ERROR:: Please supply {0} as an environment variable.".format(str(e))
+            )
             raise
     elif dns_provider == "powerdns":
         from . import PowerDNSDns
@@ -316,9 +350,13 @@ def main():
             powerdns_api_url = os.environ["POWERDNS_API_URL"]
 
             dns_class = PowerDNSDns(powerdns_api_key, powerdns_api_url)
-            logger.info("chosen_dns_provider. Using {0} as dns provider.".format(dns_provider))
+            logger.info(
+                "chosen_dns_provider. Using {0} as dns provider.".format(dns_provider)
+            )
         except KeyError as e:
-            logger.error("ERROR:: Please supply {0} as an environment variable.".format(str(e)))
+            logger.error(
+                "ERROR:: Please supply {0} as an environment variable.".format(str(e))
+            )
             raise
     elif dns_provider == "gandi":
         from . import GandiDns
@@ -327,9 +365,13 @@ def main():
             gandi_api_key = os.environ["GANDI_API_KEY"]
 
             dns_class = GandiDns(GANDI_API_KEY=gandi_api_key)
-            logger.info("chosen_dns_provider. Using {0} as dns provider.".format(dns_provider))
+            logger.info(
+                "chosen_dns_provider. Using {0} as dns provider.".format(dns_provider)
+            )
         except KeyError as e:
-            logger.error("ERROR:: Please supply {0} as an environment variable.".format(str(e)))
+            logger.error(
+                "ERROR:: Please supply {0} as an environment variable.".format(str(e))
+            )
             raise
     else:
         raise ValueError("The dns provider {0} is not recognised.".format(dns_provider))

--- a/sewer/dns_providers/__init__.py
+++ b/sewer/dns_providers/__init__.py
@@ -10,3 +10,4 @@ from .duckdns import DuckDNSDns  # noqa: F401
 from .cloudns import ClouDNSDns  # noqa: F401
 from .route53 import Route53Dns  # noqa: F401
 from .powerdns import PowerDNSDns
+from .gandi import GandiDns

--- a/sewer/dns_providers/gandi.py
+++ b/sewer/dns_providers/gandi.py
@@ -15,7 +15,7 @@ class GandiDns(common.BaseDns):
         GANDI_API_KEY=None,
         GANDI_API_BASE_URL="https://dns.api.gandi.net/api/v5/",
         DEFAULT_TTL=10800,
-        requests_lib=requests
+        requests_lib=requests,
     ):
         self.GANDI_API_KEY = GANDI_API_KEY
         self.HTTP_TIMEOUT = 65  # seconds
@@ -29,12 +29,13 @@ class GandiDns(common.BaseDns):
 
         # pass an API key
         if not GANDI_API_KEY:
-            raise ValueError(
-                "Error initializing Gandi DNS adapter. Pass an API key."
-            )
+            raise ValueError("Error initializing Gandi DNS adapter. Pass an API key.")
 
         self.GET_HEADERS = {"X-Api-Key": self.GANDI_API_KEY}
-        self.POST_HEADERS = {"X-Api-Key": self.GANDI_API_KEY, "Content-Type": "application/json"}
+        self.POST_HEADERS = {
+            "X-Api-Key": self.GANDI_API_KEY,
+            "Content-Type": "application/json",
+        }
 
         super(GandiDns, self).__init__()
 
@@ -44,31 +45,33 @@ class GandiDns(common.BaseDns):
         zone_records_href = self.get_zone_records_href(base_domain)
 
         request_body = {
-            "rrset_type": 'TXT',
+            "rrset_type": "TXT",
             "rrset_ttl": self.RECORD_TTL,
             "rrset_name": GandiDns.subdomain_to_challenge_domain(subdomain),
-            "rrset_values": [domain_dns_value]
+            "rrset_values": [domain_dns_value],
         }
 
         create_record_resp = self.requests.post(
-            zone_records_href,
-            headers=self.POST_HEADERS,
-            json=request_body
+            zone_records_href, headers=self.POST_HEADERS, json=request_body
         )
         if not create_record_resp.status_code < 300:
-            raise RuntimeError('createRecord failed')
+            raise RuntimeError("createRecord failed")
 
     def delete_dns_record(self, domain_name, domain_dns_value):
         self.delete_record(domain_name)
 
     def delete_record(self, domain_name, idempotent=False):
         def get_subdomain_record(subdomain, all_records):
-            subdomain_records = list(filter(lambda rec: rec['rrset_name'] == subdomain, all_records))
+            subdomain_records = list(
+                filter(lambda rec: rec["rrset_name"] == subdomain, all_records)
+            )
             if not len(subdomain_records) == 1:
                 if idempotent:
                     return None
                 else:
-                    raise RuntimeError('there is not exactly one record for domain: ' + domain_name)
+                    raise RuntimeError(
+                        "there is not exactly one record for domain: " + domain_name
+                    )
 
             return subdomain_records[0]
 
@@ -76,37 +79,34 @@ class GandiDns(common.BaseDns):
         zone_records_href = self.get_zone_records_href(base_domain)
         all_records = self.get_all_zone_records(zone_records_href)
         subdomain_record = get_subdomain_record(
-            GandiDns.subdomain_to_challenge_domain(subdomain),
-            all_records
+            GandiDns.subdomain_to_challenge_domain(subdomain), all_records
         )
 
         if subdomain_record:
             del_record_resp = self.requests.delete(
-                subdomain_record['rrset_href'],
-                headers=self.GET_HEADERS
+                subdomain_record["rrset_href"], headers=self.GET_HEADERS
             )
             if not del_record_resp.status_code < 300:
-                raise RuntimeError('deleteRecord failed')
+                raise RuntimeError("deleteRecord failed")
 
     def get_zone_records_href(self, base_domain):
         domain_resp = self.requests.get(
-            os.path.join(self.GANDI_API_BASE_URL, 'domains', base_domain),
-            headers=self.GET_HEADERS
+            os.path.join(self.GANDI_API_BASE_URL, "domains", base_domain),
+            headers=self.GET_HEADERS,
         )
 
         if not domain_resp.status_code < 300:
-            raise RuntimeError('getZoneHref failed')
+            raise RuntimeError("getZoneHref failed")
 
         domain_info = domain_resp.json()
-        return domain_info['zone_records_href']
+        return domain_info["zone_records_href"]
 
     def get_all_zone_records(self, zone_records_href):
         all_records_resp = self.requests.get(
-            zone_records_href,
-            headers=self.GET_HEADERS
+            zone_records_href, headers=self.GET_HEADERS
         )
         if not all_records_resp.status_code < 300:
-            raise RuntimeError('getAllZoneRecords failed')
+            raise RuntimeError("getAllZoneRecords failed")
 
         all_records = all_records_resp.json()
         return all_records
@@ -116,15 +116,17 @@ class GandiDns(common.BaseDns):
         def has_second_level_domain(split_domains):
             return len(split_domains) >= 2
 
-        split_domains = domain_name.split('.')
+        split_domains = domain_name.split(".")
         if not has_second_level_domain(split_domains):
-            raise RuntimeError('domain: ' + str(domain_name) + 'does not have a second level domain')
+            raise RuntimeError(
+                "domain: " + str(domain_name) + "does not have a second level domain"
+            )
 
-        separator = '.'
+        separator = "."
         base_domain = separator.join(split_domains[-2:])
         subdomain = separator.join(split_domains[0:-2])
         if not subdomain:
-            subdomain = '@'
+            subdomain = "@"
 
         return [subdomain, base_domain]
 

--- a/sewer/dns_providers/gandi.py
+++ b/sewer/dns_providers/gandi.py
@@ -32,10 +32,7 @@ class GandiDns(common.BaseDns):
             raise ValueError("Error initializing Gandi DNS adapter. Pass an API key.")
 
         self.GET_HEADERS = {"X-Api-Key": self.GANDI_API_KEY}
-        self.POST_HEADERS = {
-            "X-Api-Key": self.GANDI_API_KEY,
-            "Content-Type": "application/json",
-        }
+        self.POST_HEADERS = {"X-Api-Key": self.GANDI_API_KEY, "Content-Type": "application/json"}
 
         super(GandiDns, self).__init__()
 
@@ -89,7 +86,7 @@ class GandiDns(common.BaseDns):
 
     def get_zone_records_href(self, base_domain):
         domain_resp = self.requests.get(
-            os.path.join(self.GANDI_API_BASE_URL, "domains", base_domain), headers=self.GET_HEADERS,
+            os.path.join(self.GANDI_API_BASE_URL, "domains", base_domain), headers=self.GET_HEADERS
         )
 
         if not domain_resp.status_code < 300:

--- a/sewer/dns_providers/gandi.py
+++ b/sewer/dns_providers/gandi.py
@@ -1,0 +1,133 @@
+import os
+import requests
+
+from . import common
+
+
+class GandiDns(common.BaseDns):
+    """
+    """
+
+    dns_provider_name = "gandi"
+
+    def __init__(
+        self,
+        GANDI_API_KEY=None,
+        GANDI_API_BASE_URL="https://dns.api.gandi.net/api/v5/",
+        DEFAULT_TTL=10800,
+        requests_lib=requests
+    ):
+        self.GANDI_API_KEY = GANDI_API_KEY
+        self.HTTP_TIMEOUT = 65  # seconds
+        self.RECORD_TTL = DEFAULT_TTL
+        self.requests = requests_lib
+
+        if GANDI_API_BASE_URL[-1] != "/":
+            self.GANDI_API_BASE_URL = GANDI_API_BASE_URL + "/"
+        else:
+            self.GANDI_API_BASE_URL = GANDI_API_BASE_URL
+
+        # pass an API key
+        if not GANDI_API_KEY:
+            raise ValueError(
+                "Error initializing Gandi DNS adapter. Pass an API key."
+            )
+
+        self.GET_HEADERS = {"X-Api-Key": self.GANDI_API_KEY}
+        self.POST_HEADERS = {"X-Api-Key": self.GANDI_API_KEY, "Content-Type": "application/json"}
+
+        super(GandiDns, self).__init__()
+
+    def create_dns_record(self, domain_name, domain_dns_value):
+        self.delete_record(domain_name, idempotent=True)
+        [subdomain, base_domain] = GandiDns.split_domain(domain_name)
+        zone_records_href = self.get_zone_records_href(base_domain)
+
+        request_body = {
+            "rrset_type": 'TXT',
+            "rrset_ttl": self.RECORD_TTL,
+            "rrset_name": GandiDns.subdomain_to_challenge_domain(subdomain),
+            "rrset_values": [domain_dns_value]
+        }
+
+        create_record_resp = self.requests.post(
+            zone_records_href,
+            headers=self.POST_HEADERS,
+            json=request_body
+        )
+        if not create_record_resp.status_code < 300:
+            raise RuntimeError('createRecord failed')
+
+    def delete_dns_record(self, domain_name, domain_dns_value):
+        self.delete_record(domain_name)
+
+    def delete_record(self, domain_name, idempotent=False):
+        def get_subdomain_record(subdomain, all_records):
+            subdomain_records = list(filter(lambda rec: rec['rrset_name'] == subdomain, all_records))
+            if not len(subdomain_records) == 1:
+                if idempotent:
+                    return None
+                else:
+                    raise RuntimeError('there is not exactly one record for domain: ' + domain_name)
+
+            return subdomain_records[0]
+
+        [subdomain, base_domain] = GandiDns.split_domain(domain_name)
+        zone_records_href = self.get_zone_records_href(base_domain)
+        all_records = self.get_all_zone_records(zone_records_href)
+        subdomain_record = get_subdomain_record(
+            GandiDns.subdomain_to_challenge_domain(subdomain),
+            all_records
+        )
+
+        if subdomain_record:
+            del_record_resp = self.requests.delete(
+                subdomain_record['rrset_href'],
+                headers=self.GET_HEADERS
+            )
+            if not del_record_resp.status_code < 300:
+                raise RuntimeError('deleteRecord failed')
+
+    def get_zone_records_href(self, base_domain):
+        domain_resp = self.requests.get(
+            os.path.join(self.GANDI_API_BASE_URL, 'domains', base_domain),
+            headers=self.GET_HEADERS
+        )
+
+        if not domain_resp.status_code < 300:
+            raise RuntimeError('getZoneHref failed')
+
+        domain_info = domain_resp.json()
+        return domain_info['zone_records_href']
+
+    def get_all_zone_records(self, zone_records_href):
+        all_records_resp = self.requests.get(
+            zone_records_href,
+            headers=self.GET_HEADERS
+        )
+        if not all_records_resp.status_code < 300:
+            raise RuntimeError('getAllZoneRecords failed')
+
+        all_records = all_records_resp.json()
+        return all_records
+
+    @staticmethod
+    def split_domain(domain_name):
+        def has_second_level_domain(split_domains):
+            return len(split_domains) >= 2
+
+        split_domains = domain_name.split('.')
+        if not has_second_level_domain(split_domains):
+            raise RuntimeError('domain: ' + str(domain_name) + 'does not have a second level domain')
+
+        separator = '.'
+        base_domain = separator.join(split_domains[-2:])
+        subdomain = separator.join(split_domains[0:-2])
+        if not subdomain:
+            subdomain = '@'
+
+        return [subdomain, base_domain]
+
+    @staticmethod
+    def subdomain_to_challenge_domain(subdomain):
+        return "_acme-challenge" + "." + subdomain

--- a/sewer/dns_providers/gandi.py
+++ b/sewer/dns_providers/gandi.py
@@ -69,9 +69,7 @@ class GandiDns(common.BaseDns):
                 if idempotent:
                     return None
                 else:
-                    raise RuntimeError(
-                        "there is not exactly one record for domain: " + domain_name
-                    )
+                    raise RuntimeError("there is not exactly one record for domain: " + domain_name)
 
             return subdomain_records[0]
 
@@ -91,8 +89,7 @@ class GandiDns(common.BaseDns):
 
     def get_zone_records_href(self, base_domain):
         domain_resp = self.requests.get(
-            os.path.join(self.GANDI_API_BASE_URL, "domains", base_domain),
-            headers=self.GET_HEADERS,
+            os.path.join(self.GANDI_API_BASE_URL, "domains", base_domain), headers=self.GET_HEADERS,
         )
 
         if not domain_resp.status_code < 300:
@@ -102,9 +99,7 @@ class GandiDns(common.BaseDns):
         return domain_info["zone_records_href"]
 
     def get_all_zone_records(self, zone_records_href):
-        all_records_resp = self.requests.get(
-            zone_records_href, headers=self.GET_HEADERS
-        )
+        all_records_resp = self.requests.get(zone_records_href, headers=self.GET_HEADERS)
         if not all_records_resp.status_code < 300:
             raise RuntimeError("getAllZoneRecords failed")
 

--- a/sewer/dns_providers/tests/test_gandi.py
+++ b/sewer/dns_providers/tests/test_gandi.py
@@ -17,13 +17,8 @@ class MockResponseObject:
 
 def add_side_effect_to_request_get(mock_requests_get):
     def mock_implementation(*args, **kwargs):
-        if (
-            args[0]
-            == "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld"
-        ):
-            return MockResponseObject(
-                body={"zone_records_href": "mock_zone_records_href"}
-            )
+        if args[0] == "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld":
+            return MockResponseObject(body={"zone_records_href": "mock_zone_records_href"})
 
         if args[0] == "mock_zone_records_href":
             return MockResponseObject(
@@ -103,33 +98,24 @@ class TestGandiDns(TestCase):
 
     @mock_requests
     def test_delete_existing_record(self, mock_requests_lib):
-        gandi_dns = sewer.GandiDns(
-            GANDI_API_KEY=MOCK_GANDI_API_KEY, requests_lib=mock_requests_lib
-        )
-        gandi_dns.delete_dns_record(
-            "subsubdomain.subdomain.second-level-domain.tld", "val"
-        )
+        gandi_dns = sewer.GandiDns(GANDI_API_KEY=MOCK_GANDI_API_KEY, requests_lib=mock_requests_lib)
+        gandi_dns.delete_dns_record("subsubdomain.subdomain.second-level-domain.tld", "val")
 
         get_calls = mock_requests_lib.get.call_args_list
         delete_calls = mock_requests_lib.delete.call_args_list
 
         self.check_correct_headers_passed(get_calls, TestGandiDns.EXPECTED_GET_HEADERS)
-        self.check_correct_headers_passed(
-            delete_calls, TestGandiDns.EXPECTED_GET_HEADERS
-        )
+        self.check_correct_headers_passed(delete_calls, TestGandiDns.EXPECTED_GET_HEADERS)
 
         self.assertEqual(
-            get_calls[0][0][0],
-            "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld",
+            get_calls[0][0][0], "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld",
         )
         self.assertEqual(get_calls[1][0][0], "mock_zone_records_href")
         self.assertEqual(delete_calls[0][0][0], "mock_record_href")
 
     @mock_requests
     def test_delete_non_existing_record(self, mock_requests_lib):
-        gandi_dns = sewer.GandiDns(
-            GANDI_API_KEY=MOCK_GANDI_API_KEY, requests_lib=mock_requests_lib
-        )
+        gandi_dns = sewer.GandiDns(GANDI_API_KEY=MOCK_GANDI_API_KEY, requests_lib=mock_requests_lib)
         with self.assertRaises(RuntimeError) as context:
             gandi_dns.delete_dns_record("no-exist.second-level-domain.tld", "val")
 
@@ -140,50 +126,37 @@ class TestGandiDns(TestCase):
 
     @mock_requests
     def test_create_record(self, mock_requests_lib):
-        gandi_dns = sewer.GandiDns(
-            GANDI_API_KEY=MOCK_GANDI_API_KEY, requests_lib=mock_requests_lib
-        )
-        gandi_dns.create_dns_record(
-            "subsubdomain.subdomain.second-level-domain.tld", "val"
-        )
+        gandi_dns = sewer.GandiDns(GANDI_API_KEY=MOCK_GANDI_API_KEY, requests_lib=mock_requests_lib)
+        gandi_dns.create_dns_record("subsubdomain.subdomain.second-level-domain.tld", "val")
 
         get_calls = mock_requests_lib.get.call_args_list
         post_calls = mock_requests_lib.post.call_args_list
         delete_calls = mock_requests_lib.delete.call_args_list
 
         self.check_correct_headers_passed(get_calls, TestGandiDns.EXPECTED_GET_HEADERS)
-        self.check_correct_headers_passed(
-            post_calls, TestGandiDns.EXPECTED_POST_HEADERS
-        )
-        self.check_correct_headers_passed(
-            delete_calls, TestGandiDns.EXPECTED_GET_HEADERS
-        )
+        self.check_correct_headers_passed(post_calls, TestGandiDns.EXPECTED_POST_HEADERS)
+        self.check_correct_headers_passed(delete_calls, TestGandiDns.EXPECTED_GET_HEADERS)
 
         self.assertEqual(
-            get_calls[0][0][0],
-            "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld",
+            get_calls[0][0][0], "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld",
         )
         self.assertEqual(get_calls[1][0][0], "mock_zone_records_href")
         self.assertEqual(delete_calls[0][0][0], "mock_record_href")
 
         self.assertEqual(
-            get_calls[2][0][0],
-            "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld",
+            get_calls[2][0][0], "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld",
         )
         self.assertEqual(post_calls[0][0][0], "mock_zone_records_href")
         self.assertEqual(post_calls[0][1]["json"]["rrset_type"], "TXT")
         self.assertEqual(post_calls[0][1]["json"]["rrset_ttl"], 10800)
         self.assertEqual(
-            post_calls[0][1]["json"]["rrset_name"],
-            "_acme-challenge.subsubdomain.subdomain",
+            post_calls[0][1]["json"]["rrset_name"], "_acme-challenge.subsubdomain.subdomain",
         )
         self.assertEqual(post_calls[0][1]["json"]["rrset_values"], ["val"])
 
     @mock_requests
     def test_create_non_existing_record(self, mock_requests_lib):
-        gandi_dns = sewer.GandiDns(
-            GANDI_API_KEY=MOCK_GANDI_API_KEY, requests_lib=mock_requests_lib
-        )
+        gandi_dns = sewer.GandiDns(GANDI_API_KEY=MOCK_GANDI_API_KEY, requests_lib=mock_requests_lib)
         gandi_dns.create_dns_record("subdomain.second-level-domain.tld", "val")
 
         get_calls = mock_requests_lib.get.call_args_list
@@ -191,28 +164,20 @@ class TestGandiDns(TestCase):
         delete_calls = mock_requests_lib.delete.call_args_list
 
         self.check_correct_headers_passed(get_calls, TestGandiDns.EXPECTED_GET_HEADERS)
-        self.check_correct_headers_passed(
-            post_calls, TestGandiDns.EXPECTED_POST_HEADERS
-        )
-        self.check_correct_headers_passed(
-            delete_calls, TestGandiDns.EXPECTED_GET_HEADERS
-        )
+        self.check_correct_headers_passed(post_calls, TestGandiDns.EXPECTED_POST_HEADERS)
+        self.check_correct_headers_passed(delete_calls, TestGandiDns.EXPECTED_GET_HEADERS)
 
         self.assertEqual(
-            get_calls[0][0][0],
-            "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld",
+            get_calls[0][0][0], "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld",
         )
         self.assertEqual(get_calls[1][0][0], "mock_zone_records_href")
         self.assertEqual(len(delete_calls), 0)
 
         self.assertEqual(
-            get_calls[2][0][0],
-            "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld",
+            get_calls[2][0][0], "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld",
         )
         self.assertEqual(post_calls[0][0][0], "mock_zone_records_href")
         self.assertEqual(post_calls[0][1]["json"]["rrset_type"], "TXT")
         self.assertEqual(post_calls[0][1]["json"]["rrset_ttl"], 10800)
-        self.assertEqual(
-            post_calls[0][1]["json"]["rrset_name"], "_acme-challenge.subdomain"
-        )
+        self.assertEqual(post_calls[0][1]["json"]["rrset_name"], "_acme-challenge.subdomain")
         self.assertEqual(post_calls[0][1]["json"]["rrset_values"], ["val"])

--- a/sewer/dns_providers/tests/test_gandi.py
+++ b/sewer/dns_providers/tests/test_gandi.py
@@ -87,10 +87,7 @@ class TestGandiDns(TestCase):
 
     EXPECTED_GET_HEADERS = {"X-Api-Key": MOCK_GANDI_API_KEY}
 
-    EXPECTED_POST_HEADERS = {
-        "X-Api-Key": MOCK_GANDI_API_KEY,
-        "Content-Type": "application/json",
-    }
+    EXPECTED_POST_HEADERS = {"X-Api-Key": MOCK_GANDI_API_KEY, "Content-Type": "application/json"}
 
     def check_correct_headers_passed(self, calls, expectedHeaders):
         for call in calls:
@@ -108,7 +105,7 @@ class TestGandiDns(TestCase):
         self.check_correct_headers_passed(delete_calls, TestGandiDns.EXPECTED_GET_HEADERS)
 
         self.assertEqual(
-            get_calls[0][0][0], "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld",
+            get_calls[0][0][0], "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld"
         )
         self.assertEqual(get_calls[1][0][0], "mock_zone_records_href")
         self.assertEqual(delete_calls[0][0][0], "mock_record_href")
@@ -138,19 +135,19 @@ class TestGandiDns(TestCase):
         self.check_correct_headers_passed(delete_calls, TestGandiDns.EXPECTED_GET_HEADERS)
 
         self.assertEqual(
-            get_calls[0][0][0], "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld",
+            get_calls[0][0][0], "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld"
         )
         self.assertEqual(get_calls[1][0][0], "mock_zone_records_href")
         self.assertEqual(delete_calls[0][0][0], "mock_record_href")
 
         self.assertEqual(
-            get_calls[2][0][0], "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld",
+            get_calls[2][0][0], "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld"
         )
         self.assertEqual(post_calls[0][0][0], "mock_zone_records_href")
         self.assertEqual(post_calls[0][1]["json"]["rrset_type"], "TXT")
         self.assertEqual(post_calls[0][1]["json"]["rrset_ttl"], 10800)
         self.assertEqual(
-            post_calls[0][1]["json"]["rrset_name"], "_acme-challenge.subsubdomain.subdomain",
+            post_calls[0][1]["json"]["rrset_name"], "_acme-challenge.subsubdomain.subdomain"
         )
         self.assertEqual(post_calls[0][1]["json"]["rrset_values"], ["val"])
 
@@ -168,13 +165,13 @@ class TestGandiDns(TestCase):
         self.check_correct_headers_passed(delete_calls, TestGandiDns.EXPECTED_GET_HEADERS)
 
         self.assertEqual(
-            get_calls[0][0][0], "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld",
+            get_calls[0][0][0], "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld"
         )
         self.assertEqual(get_calls[1][0][0], "mock_zone_records_href")
         self.assertEqual(len(delete_calls), 0)
 
         self.assertEqual(
-            get_calls[2][0][0], "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld",
+            get_calls[2][0][0], "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld"
         )
         self.assertEqual(post_calls[0][0][0], "mock_zone_records_href")
         self.assertEqual(post_calls[0][1]["json"]["rrset_type"], "TXT")

--- a/sewer/dns_providers/tests/test_gandi.py
+++ b/sewer/dns_providers/tests/test_gandi.py
@@ -1,0 +1,154 @@
+from unittest import mock
+from unittest import TestCase
+
+import sewer
+
+MOCK_GANDI_API_KEY = 'gandi-Api-Key'
+
+class MockResponseObject:
+    def __init__(self, status_code=200, body=None):
+        self.status_code = status_code
+        self.body = body
+
+    def json(self):
+        return self.body
+
+
+def add_side_effect_to_request_get(mock_requests_get):
+    def mock_implementation(*args, **kwargs):
+        assert kwargs['headers'] == {"X-Api-Key": MOCK_GANDI_API_KEY}, 'Get headers not set'
+
+        if args[0] == 'https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld':
+            return MockResponseObject(body={
+                'zone_records_href': 'mock_zone_records_href'
+            })
+
+        if args[0] == 'mock_zone_records_href':
+            return MockResponseObject(body=[
+                {
+                    'rrset_href': 'mock_record_href',
+                    'rrset_type': 'TXT',
+                    'rrset_ttl': 10800,
+                    'rrset_name': '_acme-challenge.subsubdomain.subdomain',
+                    'rrset_values': [
+                        'challenge_text'
+                    ]
+                }
+            ])
+
+        return MockResponseObject(status_code=404)
+
+    mock_requests_get.side_effect = mock_implementation
+
+
+def add_side_effect_to_request_post(mock_requests_post):
+    def mock_implementation(*args, **kwargs):
+        assert kwargs['headers'] == {
+            "X-Api-Key": MOCK_GANDI_API_KEY,
+            "Content-Type": "application/json"},\
+            'Post headers not set'
+
+        if args[0] == 'mock_zone_records_href':
+            return MockResponseObject()
+
+        return MockResponseObject(status_code=404)
+
+    mock_requests_post.side_effect = mock_implementation
+
+
+def add_side_effect_to_request_delete(mock_requests_delete):
+    def mock_implementation(*args, **kwargs):
+        assert kwargs['headers'] == {"X-Api-Key": MOCK_GANDI_API_KEY}, 'Get headers not set'
+
+        if args[0] == 'mock_record_href':
+            return MockResponseObject()
+
+        return MockResponseObject(status_code=404)
+
+    mock_requests_delete.side_effect = mock_implementation
+
+
+@mock.patch('requests.delete')
+@mock.patch('requests.post')
+@mock.patch('requests.get')
+def mock_requests(func, mock_requests_get, mock_requests_post, mock_requests_delete):
+    class MockRequests:
+        def __init__(self, mock_get, mock_post, mock_delete):
+            self.get = mock_get
+            self.post = mock_post
+            self.delete = mock_delete
+
+    def add_mock_implementations():
+        add_side_effect_to_request_get(mock_requests_get)
+        add_side_effect_to_request_post(mock_requests_post)
+        add_side_effect_to_request_delete(mock_requests_delete)
+
+    def inner(*args, **kwargs):
+        mock_requests_lib = MockRequests(mock_requests_get, mock_requests_post, mock_requests_delete)
+        return func(*[*args, mock_requests_lib], **kwargs)
+
+    add_mock_implementations()
+    return inner
+
+
+class TestGandiDns(TestCase):
+
+    @mock_requests
+    def test_delete_existing_record(self, mock_requests_lib):
+        gandi_dns = sewer.GandiDns(GANDI_API_KEY=MOCK_GANDI_API_KEY, requests_lib=mock_requests_lib)
+        gandi_dns.delete_dns_record('subsubdomain.subdomain.second-level-domain.tld', 'val')
+
+        getCalls = mock_requests_lib.get.call_args_list
+        deleteCalls = mock_requests_lib.delete.call_args_list
+
+        self.assertEqual(getCalls[0][0][0], 'https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld')
+        self.assertEqual(getCalls[1][0][0], 'mock_zone_records_href')
+        self.assertEqual(deleteCalls[0][0][0], 'mock_record_href')
+
+    @mock_requests
+    def test_delete_non_existing_record(self, mock_requests_lib):
+        gandi_dns = sewer.GandiDns(GANDI_API_KEY=MOCK_GANDI_API_KEY, requests_lib=mock_requests_lib)
+        with self.assertRaises(RuntimeError) as context:
+            gandi_dns.delete_dns_record('no-exist.second-level-domain.tld', 'val')
+
+        self.assertEqual('there is not exactly one record for domain: no-exist.second-level-domain.tld', str(context.exception))
+
+    @mock_requests
+    def test_create_record(self, mock_requests_lib):
+        gandi_dns = sewer.GandiDns(GANDI_API_KEY=MOCK_GANDI_API_KEY, requests_lib=mock_requests_lib)
+        gandi_dns.create_dns_record('subsubdomain.subdomain.second-level-domain.tld', 'val')
+
+        getCalls = mock_requests_lib.get.call_args_list
+        postCalls = mock_requests_lib.post.call_args_list
+        deleteCalls = mock_requests_lib.delete.call_args_list
+
+        self.assertEqual(getCalls[0][0][0], 'https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld')
+        self.assertEqual(getCalls[1][0][0], 'mock_zone_records_href')
+        self.assertEqual(deleteCalls[0][0][0], 'mock_record_href')
+
+        self.assertEqual(getCalls[2][0][0], 'https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld')
+        self.assertEqual(postCalls[0][0][0], 'mock_zone_records_href')
+        self.assertEqual(postCalls[0][1]['json']['rrset_type'], 'TXT')
+        self.assertEqual(postCalls[0][1]['json']['rrset_ttl'], 10800)
+        self.assertEqual(postCalls[0][1]['json']['rrset_name'], '_acme-challenge.subsubdomain.subdomain')
+        self.assertEqual(postCalls[0][1]['json']['rrset_values'], ['val'])
+
+    @mock_requests
+    def test_create_non_existing_record(self, mock_requests_lib):
+        gandi_dns = sewer.GandiDns(GANDI_API_KEY=MOCK_GANDI_API_KEY, requests_lib=mock_requests_lib)
+        gandi_dns.create_dns_record('subdomain.second-level-domain.tld', 'val')
+
+        getCalls = mock_requests_lib.get.call_args_list
+        postCalls = mock_requests_lib.post.call_args_list
+        deleteCalls = mock_requests_lib.delete.call_args_list
+
+        self.assertEqual(getCalls[0][0][0], 'https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld')
+        self.assertEqual(getCalls[1][0][0], 'mock_zone_records_href')
+        self.assertEqual(len(deleteCalls), 0)
+
+        self.assertEqual(getCalls[2][0][0], 'https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld')
+        self.assertEqual(postCalls[0][0][0], 'mock_zone_records_href')
+        self.assertEqual(postCalls[0][1]['json']['rrset_type'], 'TXT')
+        self.assertEqual(postCalls[0][1]['json']['rrset_ttl'], 10800)
+        self.assertEqual(postCalls[0][1]['json']['rrset_name'], '_acme-challenge.subdomain')
+        self.assertEqual(postCalls[0][1]['json']['rrset_values'], ['val'])

--- a/sewer/dns_providers/tests/test_gandi.py
+++ b/sewer/dns_providers/tests/test_gandi.py
@@ -16,8 +16,6 @@ class MockResponseObject:
 
 def add_side_effect_to_request_get(mock_requests_get):
     def mock_implementation(*args, **kwargs):
-        assert kwargs['headers'] == {"X-Api-Key": MOCK_GANDI_API_KEY}, 'Get headers not set'
-
         if args[0] == 'https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld':
             return MockResponseObject(body={
                 'zone_records_href': 'mock_zone_records_href'
@@ -43,11 +41,6 @@ def add_side_effect_to_request_get(mock_requests_get):
 
 def add_side_effect_to_request_post(mock_requests_post):
     def mock_implementation(*args, **kwargs):
-        assert kwargs['headers'] == {
-            "X-Api-Key": MOCK_GANDI_API_KEY,
-            "Content-Type": "application/json"},\
-            'Post headers not set'
-
         if args[0] == 'mock_zone_records_href':
             return MockResponseObject()
 
@@ -58,8 +51,6 @@ def add_side_effect_to_request_post(mock_requests_post):
 
 def add_side_effect_to_request_delete(mock_requests_delete):
     def mock_implementation(*args, **kwargs):
-        assert kwargs['headers'] == {"X-Api-Key": MOCK_GANDI_API_KEY}, 'Get headers not set'
-
         if args[0] == 'mock_record_href':
             return MockResponseObject()
 
@@ -93,17 +84,33 @@ def mock_requests(func, mock_requests_get, mock_requests_post, mock_requests_del
 
 class TestGandiDns(TestCase):
 
+    EXPECTED_GET_HEADERS = {
+        "X-Api-Key": MOCK_GANDI_API_KEY
+    }
+
+    EXPECTED_POST_HEADERS = {
+        "X-Api-Key": MOCK_GANDI_API_KEY,
+        "Content-Type": "application/json"
+    }
+
+    def check_correct_headers_passed(self, calls, expectedHeaders):
+        for call in calls:
+            self.assertEqual(call[1]['headers'], expectedHeaders)
+
     @mock_requests
     def test_delete_existing_record(self, mock_requests_lib):
         gandi_dns = sewer.GandiDns(GANDI_API_KEY=MOCK_GANDI_API_KEY, requests_lib=mock_requests_lib)
         gandi_dns.delete_dns_record('subsubdomain.subdomain.second-level-domain.tld', 'val')
 
-        getCalls = mock_requests_lib.get.call_args_list
-        deleteCalls = mock_requests_lib.delete.call_args_list
+        get_calls = mock_requests_lib.get.call_args_list
+        delete_calls = mock_requests_lib.delete.call_args_list
 
-        self.assertEqual(getCalls[0][0][0], 'https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld')
-        self.assertEqual(getCalls[1][0][0], 'mock_zone_records_href')
-        self.assertEqual(deleteCalls[0][0][0], 'mock_record_href')
+        self.check_correct_headers_passed(get_calls, TestGandiDns.EXPECTED_GET_HEADERS)
+        self.check_correct_headers_passed(delete_calls, TestGandiDns.EXPECTED_GET_HEADERS)
+
+        self.assertEqual(get_calls[0][0][0], 'https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld')
+        self.assertEqual(get_calls[1][0][0], 'mock_zone_records_href')
+        self.assertEqual(delete_calls[0][0][0], 'mock_record_href')
 
     @mock_requests
     def test_delete_non_existing_record(self, mock_requests_lib):
@@ -118,37 +125,45 @@ class TestGandiDns(TestCase):
         gandi_dns = sewer.GandiDns(GANDI_API_KEY=MOCK_GANDI_API_KEY, requests_lib=mock_requests_lib)
         gandi_dns.create_dns_record('subsubdomain.subdomain.second-level-domain.tld', 'val')
 
-        getCalls = mock_requests_lib.get.call_args_list
-        postCalls = mock_requests_lib.post.call_args_list
-        deleteCalls = mock_requests_lib.delete.call_args_list
+        get_calls = mock_requests_lib.get.call_args_list
+        post_calls = mock_requests_lib.post.call_args_list
+        delete_calls = mock_requests_lib.delete.call_args_list
 
-        self.assertEqual(getCalls[0][0][0], 'https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld')
-        self.assertEqual(getCalls[1][0][0], 'mock_zone_records_href')
-        self.assertEqual(deleteCalls[0][0][0], 'mock_record_href')
+        self.check_correct_headers_passed(get_calls, TestGandiDns.EXPECTED_GET_HEADERS)
+        self.check_correct_headers_passed(post_calls, TestGandiDns.EXPECTED_POST_HEADERS)
+        self.check_correct_headers_passed(delete_calls, TestGandiDns.EXPECTED_GET_HEADERS)
 
-        self.assertEqual(getCalls[2][0][0], 'https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld')
-        self.assertEqual(postCalls[0][0][0], 'mock_zone_records_href')
-        self.assertEqual(postCalls[0][1]['json']['rrset_type'], 'TXT')
-        self.assertEqual(postCalls[0][1]['json']['rrset_ttl'], 10800)
-        self.assertEqual(postCalls[0][1]['json']['rrset_name'], '_acme-challenge.subsubdomain.subdomain')
-        self.assertEqual(postCalls[0][1]['json']['rrset_values'], ['val'])
+        self.assertEqual(get_calls[0][0][0], 'https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld')
+        self.assertEqual(get_calls[1][0][0], 'mock_zone_records_href')
+        self.assertEqual(delete_calls[0][0][0], 'mock_record_href')
+
+        self.assertEqual(get_calls[2][0][0], 'https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld')
+        self.assertEqual(post_calls[0][0][0], 'mock_zone_records_href')
+        self.assertEqual(post_calls[0][1]['json']['rrset_type'], 'TXT')
+        self.assertEqual(post_calls[0][1]['json']['rrset_ttl'], 10800)
+        self.assertEqual(post_calls[0][1]['json']['rrset_name'], '_acme-challenge.subsubdomain.subdomain')
+        self.assertEqual(post_calls[0][1]['json']['rrset_values'], ['val'])
 
     @mock_requests
     def test_create_non_existing_record(self, mock_requests_lib):
         gandi_dns = sewer.GandiDns(GANDI_API_KEY=MOCK_GANDI_API_KEY, requests_lib=mock_requests_lib)
         gandi_dns.create_dns_record('subdomain.second-level-domain.tld', 'val')
 
-        getCalls = mock_requests_lib.get.call_args_list
-        postCalls = mock_requests_lib.post.call_args_list
-        deleteCalls = mock_requests_lib.delete.call_args_list
+        get_calls = mock_requests_lib.get.call_args_list
+        post_calls = mock_requests_lib.post.call_args_list
+        delete_calls = mock_requests_lib.delete.call_args_list
 
-        self.assertEqual(getCalls[0][0][0], 'https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld')
-        self.assertEqual(getCalls[1][0][0], 'mock_zone_records_href')
-        self.assertEqual(len(deleteCalls), 0)
+        self.check_correct_headers_passed(get_calls, TestGandiDns.EXPECTED_GET_HEADERS)
+        self.check_correct_headers_passed(post_calls, TestGandiDns.EXPECTED_POST_HEADERS)
+        self.check_correct_headers_passed(delete_calls, TestGandiDns.EXPECTED_GET_HEADERS)
 
-        self.assertEqual(getCalls[2][0][0], 'https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld')
-        self.assertEqual(postCalls[0][0][0], 'mock_zone_records_href')
-        self.assertEqual(postCalls[0][1]['json']['rrset_type'], 'TXT')
-        self.assertEqual(postCalls[0][1]['json']['rrset_ttl'], 10800)
-        self.assertEqual(postCalls[0][1]['json']['rrset_name'], '_acme-challenge.subdomain')
-        self.assertEqual(postCalls[0][1]['json']['rrset_values'], ['val'])
+        self.assertEqual(get_calls[0][0][0], 'https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld')
+        self.assertEqual(get_calls[1][0][0], 'mock_zone_records_href')
+        self.assertEqual(len(delete_calls), 0)
+
+        self.assertEqual(get_calls[2][0][0], 'https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld')
+        self.assertEqual(post_calls[0][0][0], 'mock_zone_records_href')
+        self.assertEqual(post_calls[0][1]['json']['rrset_type'], 'TXT')
+        self.assertEqual(post_calls[0][1]['json']['rrset_ttl'], 10800)
+        self.assertEqual(post_calls[0][1]['json']['rrset_name'], '_acme-challenge.subdomain')
+        self.assertEqual(post_calls[0][1]['json']['rrset_values'], ['val'])

--- a/sewer/dns_providers/tests/test_gandi.py
+++ b/sewer/dns_providers/tests/test_gandi.py
@@ -3,7 +3,8 @@ from unittest import TestCase
 
 import sewer
 
-MOCK_GANDI_API_KEY = 'gandi-Api-Key'
+MOCK_GANDI_API_KEY = "gandi-Api-Key"
+
 
 class MockResponseObject:
     def __init__(self, status_code=200, body=None):
@@ -16,23 +17,26 @@ class MockResponseObject:
 
 def add_side_effect_to_request_get(mock_requests_get):
     def mock_implementation(*args, **kwargs):
-        if args[0] == 'https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld':
-            return MockResponseObject(body={
-                'zone_records_href': 'mock_zone_records_href'
-            })
+        if (
+            args[0]
+            == "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld"
+        ):
+            return MockResponseObject(
+                body={"zone_records_href": "mock_zone_records_href"}
+            )
 
-        if args[0] == 'mock_zone_records_href':
-            return MockResponseObject(body=[
-                {
-                    'rrset_href': 'mock_record_href',
-                    'rrset_type': 'TXT',
-                    'rrset_ttl': 10800,
-                    'rrset_name': '_acme-challenge.subsubdomain.subdomain',
-                    'rrset_values': [
-                        'challenge_text'
-                    ]
-                }
-            ])
+        if args[0] == "mock_zone_records_href":
+            return MockResponseObject(
+                body=[
+                    {
+                        "rrset_href": "mock_record_href",
+                        "rrset_type": "TXT",
+                        "rrset_ttl": 10800,
+                        "rrset_name": "_acme-challenge.subsubdomain.subdomain",
+                        "rrset_values": ["challenge_text"],
+                    }
+                ]
+            )
 
         return MockResponseObject(status_code=404)
 
@@ -41,7 +45,7 @@ def add_side_effect_to_request_get(mock_requests_get):
 
 def add_side_effect_to_request_post(mock_requests_post):
     def mock_implementation(*args, **kwargs):
-        if args[0] == 'mock_zone_records_href':
+        if args[0] == "mock_zone_records_href":
             return MockResponseObject()
 
         return MockResponseObject(status_code=404)
@@ -51,7 +55,7 @@ def add_side_effect_to_request_post(mock_requests_post):
 
 def add_side_effect_to_request_delete(mock_requests_delete):
     def mock_implementation(*args, **kwargs):
-        if args[0] == 'mock_record_href':
+        if args[0] == "mock_record_href":
             return MockResponseObject()
 
         return MockResponseObject(status_code=404)
@@ -59,9 +63,9 @@ def add_side_effect_to_request_delete(mock_requests_delete):
     mock_requests_delete.side_effect = mock_implementation
 
 
-@mock.patch('requests.delete')
-@mock.patch('requests.post')
-@mock.patch('requests.get')
+@mock.patch("requests.delete")
+@mock.patch("requests.post")
+@mock.patch("requests.get")
 def mock_requests(func, mock_requests_get, mock_requests_post, mock_requests_delete):
     class MockRequests:
         def __init__(self, mock_get, mock_post, mock_delete):
@@ -75,7 +79,9 @@ def mock_requests(func, mock_requests_get, mock_requests_post, mock_requests_del
         add_side_effect_to_request_delete(mock_requests_delete)
 
     def inner(*args, **kwargs):
-        mock_requests_lib = MockRequests(mock_requests_get, mock_requests_post, mock_requests_delete)
+        mock_requests_lib = MockRequests(
+            mock_requests_get, mock_requests_post, mock_requests_delete
+        )
         return func(*[*args, mock_requests_lib], **kwargs)
 
     add_mock_implementations()
@@ -84,86 +90,129 @@ def mock_requests(func, mock_requests_get, mock_requests_post, mock_requests_del
 
 class TestGandiDns(TestCase):
 
-    EXPECTED_GET_HEADERS = {
-        "X-Api-Key": MOCK_GANDI_API_KEY
-    }
+    EXPECTED_GET_HEADERS = {"X-Api-Key": MOCK_GANDI_API_KEY}
 
     EXPECTED_POST_HEADERS = {
         "X-Api-Key": MOCK_GANDI_API_KEY,
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
     }
 
     def check_correct_headers_passed(self, calls, expectedHeaders):
         for call in calls:
-            self.assertEqual(call[1]['headers'], expectedHeaders)
+            self.assertEqual(call[1]["headers"], expectedHeaders)
 
     @mock_requests
     def test_delete_existing_record(self, mock_requests_lib):
-        gandi_dns = sewer.GandiDns(GANDI_API_KEY=MOCK_GANDI_API_KEY, requests_lib=mock_requests_lib)
-        gandi_dns.delete_dns_record('subsubdomain.subdomain.second-level-domain.tld', 'val')
+        gandi_dns = sewer.GandiDns(
+            GANDI_API_KEY=MOCK_GANDI_API_KEY, requests_lib=mock_requests_lib
+        )
+        gandi_dns.delete_dns_record(
+            "subsubdomain.subdomain.second-level-domain.tld", "val"
+        )
 
         get_calls = mock_requests_lib.get.call_args_list
         delete_calls = mock_requests_lib.delete.call_args_list
 
         self.check_correct_headers_passed(get_calls, TestGandiDns.EXPECTED_GET_HEADERS)
-        self.check_correct_headers_passed(delete_calls, TestGandiDns.EXPECTED_GET_HEADERS)
+        self.check_correct_headers_passed(
+            delete_calls, TestGandiDns.EXPECTED_GET_HEADERS
+        )
 
-        self.assertEqual(get_calls[0][0][0], 'https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld')
-        self.assertEqual(get_calls[1][0][0], 'mock_zone_records_href')
-        self.assertEqual(delete_calls[0][0][0], 'mock_record_href')
+        self.assertEqual(
+            get_calls[0][0][0],
+            "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld",
+        )
+        self.assertEqual(get_calls[1][0][0], "mock_zone_records_href")
+        self.assertEqual(delete_calls[0][0][0], "mock_record_href")
 
     @mock_requests
     def test_delete_non_existing_record(self, mock_requests_lib):
-        gandi_dns = sewer.GandiDns(GANDI_API_KEY=MOCK_GANDI_API_KEY, requests_lib=mock_requests_lib)
+        gandi_dns = sewer.GandiDns(
+            GANDI_API_KEY=MOCK_GANDI_API_KEY, requests_lib=mock_requests_lib
+        )
         with self.assertRaises(RuntimeError) as context:
-            gandi_dns.delete_dns_record('no-exist.second-level-domain.tld', 'val')
+            gandi_dns.delete_dns_record("no-exist.second-level-domain.tld", "val")
 
-        self.assertEqual('there is not exactly one record for domain: no-exist.second-level-domain.tld', str(context.exception))
+        self.assertEqual(
+            "there is not exactly one record for domain: no-exist.second-level-domain.tld",
+            str(context.exception),
+        )
 
     @mock_requests
     def test_create_record(self, mock_requests_lib):
-        gandi_dns = sewer.GandiDns(GANDI_API_KEY=MOCK_GANDI_API_KEY, requests_lib=mock_requests_lib)
-        gandi_dns.create_dns_record('subsubdomain.subdomain.second-level-domain.tld', 'val')
+        gandi_dns = sewer.GandiDns(
+            GANDI_API_KEY=MOCK_GANDI_API_KEY, requests_lib=mock_requests_lib
+        )
+        gandi_dns.create_dns_record(
+            "subsubdomain.subdomain.second-level-domain.tld", "val"
+        )
 
         get_calls = mock_requests_lib.get.call_args_list
         post_calls = mock_requests_lib.post.call_args_list
         delete_calls = mock_requests_lib.delete.call_args_list
 
         self.check_correct_headers_passed(get_calls, TestGandiDns.EXPECTED_GET_HEADERS)
-        self.check_correct_headers_passed(post_calls, TestGandiDns.EXPECTED_POST_HEADERS)
-        self.check_correct_headers_passed(delete_calls, TestGandiDns.EXPECTED_GET_HEADERS)
+        self.check_correct_headers_passed(
+            post_calls, TestGandiDns.EXPECTED_POST_HEADERS
+        )
+        self.check_correct_headers_passed(
+            delete_calls, TestGandiDns.EXPECTED_GET_HEADERS
+        )
 
-        self.assertEqual(get_calls[0][0][0], 'https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld')
-        self.assertEqual(get_calls[1][0][0], 'mock_zone_records_href')
-        self.assertEqual(delete_calls[0][0][0], 'mock_record_href')
+        self.assertEqual(
+            get_calls[0][0][0],
+            "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld",
+        )
+        self.assertEqual(get_calls[1][0][0], "mock_zone_records_href")
+        self.assertEqual(delete_calls[0][0][0], "mock_record_href")
 
-        self.assertEqual(get_calls[2][0][0], 'https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld')
-        self.assertEqual(post_calls[0][0][0], 'mock_zone_records_href')
-        self.assertEqual(post_calls[0][1]['json']['rrset_type'], 'TXT')
-        self.assertEqual(post_calls[0][1]['json']['rrset_ttl'], 10800)
-        self.assertEqual(post_calls[0][1]['json']['rrset_name'], '_acme-challenge.subsubdomain.subdomain')
-        self.assertEqual(post_calls[0][1]['json']['rrset_values'], ['val'])
+        self.assertEqual(
+            get_calls[2][0][0],
+            "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld",
+        )
+        self.assertEqual(post_calls[0][0][0], "mock_zone_records_href")
+        self.assertEqual(post_calls[0][1]["json"]["rrset_type"], "TXT")
+        self.assertEqual(post_calls[0][1]["json"]["rrset_ttl"], 10800)
+        self.assertEqual(
+            post_calls[0][1]["json"]["rrset_name"],
+            "_acme-challenge.subsubdomain.subdomain",
+        )
+        self.assertEqual(post_calls[0][1]["json"]["rrset_values"], ["val"])
 
     @mock_requests
     def test_create_non_existing_record(self, mock_requests_lib):
-        gandi_dns = sewer.GandiDns(GANDI_API_KEY=MOCK_GANDI_API_KEY, requests_lib=mock_requests_lib)
-        gandi_dns.create_dns_record('subdomain.second-level-domain.tld', 'val')
+        gandi_dns = sewer.GandiDns(
+            GANDI_API_KEY=MOCK_GANDI_API_KEY, requests_lib=mock_requests_lib
+        )
+        gandi_dns.create_dns_record("subdomain.second-level-domain.tld", "val")
 
         get_calls = mock_requests_lib.get.call_args_list
         post_calls = mock_requests_lib.post.call_args_list
         delete_calls = mock_requests_lib.delete.call_args_list
 
         self.check_correct_headers_passed(get_calls, TestGandiDns.EXPECTED_GET_HEADERS)
-        self.check_correct_headers_passed(post_calls, TestGandiDns.EXPECTED_POST_HEADERS)
-        self.check_correct_headers_passed(delete_calls, TestGandiDns.EXPECTED_GET_HEADERS)
+        self.check_correct_headers_passed(
+            post_calls, TestGandiDns.EXPECTED_POST_HEADERS
+        )
+        self.check_correct_headers_passed(
+            delete_calls, TestGandiDns.EXPECTED_GET_HEADERS
+        )
 
-        self.assertEqual(get_calls[0][0][0], 'https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld')
-        self.assertEqual(get_calls[1][0][0], 'mock_zone_records_href')
+        self.assertEqual(
+            get_calls[0][0][0],
+            "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld",
+        )
+        self.assertEqual(get_calls[1][0][0], "mock_zone_records_href")
         self.assertEqual(len(delete_calls), 0)
 
-        self.assertEqual(get_calls[2][0][0], 'https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld')
-        self.assertEqual(post_calls[0][0][0], 'mock_zone_records_href')
-        self.assertEqual(post_calls[0][1]['json']['rrset_type'], 'TXT')
-        self.assertEqual(post_calls[0][1]['json']['rrset_ttl'], 10800)
-        self.assertEqual(post_calls[0][1]['json']['rrset_name'], '_acme-challenge.subdomain')
-        self.assertEqual(post_calls[0][1]['json']['rrset_values'], ['val'])
+        self.assertEqual(
+            get_calls[2][0][0],
+            "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld",
+        )
+        self.assertEqual(post_calls[0][0][0], "mock_zone_records_href")
+        self.assertEqual(post_calls[0][1]["json"]["rrset_type"], "TXT")
+        self.assertEqual(post_calls[0][1]["json"]["rrset_ttl"], 10800)
+        self.assertEqual(
+            post_calls[0][1]["json"]["rrset_name"], "_acme-challenge.subdomain"
+        )
+        self.assertEqual(post_calls[0][1]["json"]["rrset_values"], ["val"])


### PR DESCRIPTION
Thank you for contributing to sewer.                    
Every contribution to sewer is important to us.                       
You may not know it, but you have just contributed to making the world a more safer and secure place.                         

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to sewer, and sewer agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that sewer shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

## What(What have you changed?)

Added a dns_provider class for the gandi DNS service
+ tests (although the requests mock is a bit hacky, see comments)
+ readme

## Why(Why did you change it?)

Because I use gandi DNS and it isn't currently supported.