### PR TITLE
log_response method deduplicated as function in lib.py

### DIFF
--- a/sewer/auth.py
+++ b/sewer/auth.py
@@ -16,16 +16,6 @@ class BaseAuthProvider(object):
 
         self.auth_type = auth_type
 
-    def log_response(self, response):
-        """
-        renders a python-requests response as json or as a string
-        """
-        try:
-            log_body = response.json()
-        except ValueError:
-            log_body = response.content
-        return log_body
-
     def fulfill_authorization(self, identifier_auth, token, acme_keyauthorization):
         """
         Called by the client to create the required authorization resource. This Could be a dns record (for dns-01)

--- a/sewer/client.py
+++ b/sewer/client.py
@@ -12,7 +12,7 @@ import cryptography
 
 from . import __version__ as sewer_version
 from .config import ACME_DIRECTORY_URL_PRODUCTION
-from .lib import safe_base64
+from .lib import log_response, safe_base64
 
 
 class Client(object):
@@ -251,18 +251,6 @@ class Client(object):
         return response
 
     @staticmethod
-    def log_response(response):
-        """
-        renders response as json or as a string
-        """
-        # TODO: use this to handle all response logs.
-        try:
-            log_body = response.json()
-        except ValueError:
-            log_body = response.content[:30]
-        return log_body
-
-    @staticmethod
     def get_user_agent():
         return "python-requests/{requests_version} ({system}: {machine}) sewer {sewer_version} ({sewer_url})".format(
             requests_version=requests.__version__,
@@ -282,7 +270,7 @@ class Client(object):
             raise ValueError(
                 "Error while getting Acme endpoints: status_code={status_code} response={response}".format(
                     status_code=get_acme_endpoints.status_code,
-                    response=self.log_response(get_acme_endpoints),
+                    response=log_response(get_acme_endpoints),
                 )
             )
         return get_acme_endpoints
@@ -364,7 +352,7 @@ class Client(object):
         acme_register_response = self.make_signed_acme_request(url=url, payload=payload)
         self.logger.debug(
             "acme_register_response. status_code={0}. response={1}".format(
-                acme_register_response.status_code, self.log_response(acme_register_response)
+                acme_register_response.status_code, log_response(acme_register_response)
             )
         )
 
@@ -372,7 +360,7 @@ class Client(object):
             raise ValueError(
                 "Error while registering: status_code={status_code} response={response}".format(
                     status_code=acme_register_response.status_code,
-                    response=self.log_response(acme_register_response),
+                    response=log_response(acme_register_response),
                 )
             )
 
@@ -411,7 +399,7 @@ class Client(object):
         self.logger.debug(
             "apply_for_cert_issuance_response. status_code={0}. response={1}".format(
                 apply_for_cert_issuance_response.status_code,
-                self.log_response(apply_for_cert_issuance_response),
+                log_response(apply_for_cert_issuance_response),
             )
         )
 
@@ -419,7 +407,7 @@ class Client(object):
             raise ValueError(
                 "Error applying for certificate issuance: status_code={status_code} response={response}".format(
                     status_code=apply_for_cert_issuance_response.status_code,
-                    response=self.log_response(apply_for_cert_issuance_response),
+                    response=log_response(apply_for_cert_issuance_response),
                 )
             )
 
@@ -445,13 +433,13 @@ class Client(object):
         response = self.GET(url)
         self.logger.debug(
             "get_identifier_authorization_response. status_code={0}. response={1}".format(
-                response.status_code, self.log_response(response)
+                response.status_code, log_response(response)
             )
         )
         if response.status_code not in [200, 201]:
             raise ValueError(
                 "Error getting identifier authorization: status_code={status_code} response={response}".format(
-                    status_code=response.status_code, response=self.log_response(response)
+                    status_code=response.status_code, response=log_response(response)
                 )
             )
         response_json = response.json()
@@ -514,7 +502,7 @@ class Client(object):
             self.logger.debug(
                 "check_authorization_status_response. status_code={0}. response={1}".format(
                     check_authorization_status_response.status_code,
-                    self.log_response(check_authorization_status_response),
+                    log_response(check_authorization_status_response),
                 )
             )
             if authorization_status in desired_status:
@@ -552,7 +540,7 @@ class Client(object):
         self.logger.debug(
             "respond_to_challenge_response. status_code={0}. response={1}".format(
                 respond_to_challenge_response.status_code,
-                self.log_response(respond_to_challenge_response),
+                log_response(respond_to_challenge_response),
             )
         )
 
@@ -577,7 +565,7 @@ class Client(object):
         send_csr_response = self.make_signed_acme_request(url=finalize_url, payload=payload)
         self.logger.debug(
             "send_csr_response. status_code={0}. response={1}".format(
-                send_csr_response.status_code, self.log_response(send_csr_response)
+                send_csr_response.status_code, log_response(send_csr_response)
             )
         )
 
@@ -585,7 +573,7 @@ class Client(object):
             raise ValueError(
                 "Error sending csr: status_code={status_code} response={response}".format(
                     status_code=send_csr_response.status_code,
-                    response=self.log_response(send_csr_response),
+                    response=log_response(send_csr_response),
                 )
             )
         send_csr_response_json = send_csr_response.json()
@@ -603,7 +591,7 @@ class Client(object):
         self.logger.debug(
             "download_certificate_response. status_code={0}. response={1}".format(
                 download_certificate_response.status_code,
-                self.log_response(download_certificate_response),
+                log_response(download_certificate_response),
             )
         )
 
@@ -611,7 +599,7 @@ class Client(object):
             raise ValueError(
                 "Error fetching signed certificate: status_code={status_code} response={response}".format(
                     status_code=download_certificate_response.status_code,
-                    response=self.log_response(download_certificate_response),
+                    response=log_response(download_certificate_response),
                 )
             )
 

--- a/sewer/dns_providers/acmedns.py
+++ b/sewer/dns_providers/acmedns.py
@@ -8,6 +8,7 @@ except ImportError:
 import requests
 
 from . import common
+from ..lib import log_response
 
 
 class AcmeDnsDns(common.BaseDns):
@@ -50,7 +51,7 @@ class AcmeDnsDns(common.BaseDns):
         self.logger.debug(
             "update_acmedns_dns_record_response. status_code={0}. response={1}".format(
                 update_acmedns_dns_record_response.status_code,
-                self.log_response(update_acmedns_dns_record_response),
+                log_response(update_acmedns_dns_record_response),
             )
         )
         if update_acmedns_dns_record_response.status_code != 200:
@@ -59,7 +60,7 @@ class AcmeDnsDns(common.BaseDns):
             raise ValueError(
                 "Error creating acme-dns dns record: status_code={status_code} response={response}".format(
                     status_code=update_acmedns_dns_record_response.status_code,
-                    response=self.log_response(update_acmedns_dns_record_response),
+                    response=log_response(update_acmedns_dns_record_response),
                 )
             )
         self.logger.info("create_dns_record_end")

--- a/sewer/dns_providers/cloudflare.py
+++ b/sewer/dns_providers/cloudflare.py
@@ -3,6 +3,7 @@ import urllib.parse
 import requests
 
 from . import common
+from ..lib import log_response
 
 
 class CloudFlareDns(common.BaseDns):
@@ -53,7 +54,7 @@ class CloudFlareDns(common.BaseDns):
             raise ValueError(
                 "Error creating cloudflare dns record: status_code={status_code} response={response}".format(
                     status_code=find_dns_zone_response.status_code,
-                    response=self.log_response(find_dns_zone_response),
+                    response=log_response(find_dns_zone_response),
                 )
             )
 
@@ -66,7 +67,7 @@ class CloudFlareDns(common.BaseDns):
                 "Error unable to get DNS zone for domain_name={domain_name}: status_code={status_code} response={response}".format(
                     domain_name=domain_name,
                     status_code=find_dns_zone_response.status_code,
-                    response=self.log_response(find_dns_zone_response),
+                    response=log_response(find_dns_zone_response),
                 )
             )
 
@@ -92,7 +93,7 @@ class CloudFlareDns(common.BaseDns):
         self.logger.debug(
             "create_cloudflare_dns_record_response. status_code={0}. response={1}".format(
                 create_cloudflare_dns_record_response.status_code,
-                self.log_response(create_cloudflare_dns_record_response),
+                log_response(create_cloudflare_dns_record_response),
             )
         )
         if create_cloudflare_dns_record_response.status_code != 200:
@@ -101,7 +102,7 @@ class CloudFlareDns(common.BaseDns):
             raise ValueError(
                 "Error creating cloudflare dns record: status_code={status_code} response={response}".format(
                     status_code=create_cloudflare_dns_record_response.status_code,
-                    response=self.log_response(create_cloudflare_dns_record_response),
+                    response=log_response(create_cloudflare_dns_record_response),
                 )
             )
         self.logger.info("create_dns_record_end")
@@ -144,8 +145,7 @@ class CloudFlareDns(common.BaseDns):
             )
             self.logger.debug(
                 "delete_dns_record_response. status_code={0}. response={1}".format(
-                    delete_dns_record_response.status_code,
-                    self.log_response(delete_dns_record_response),
+                    delete_dns_record_response.status_code, log_response(delete_dns_record_response)
                 )
             )
             if delete_dns_record_response.status_code != 200:
@@ -154,7 +154,7 @@ class CloudFlareDns(common.BaseDns):
                 self.logger.error(
                     "delete_dns_record_response. status_code={0}. response={1}".format(
                         delete_dns_record_response.status_code,
-                        self.log_response(delete_dns_record_response),
+                        log_response(delete_dns_record_response),
                     )
                 )
 

--- a/sewer/dns_providers/rackspace.py
+++ b/sewer/dns_providers/rackspace.py
@@ -1,6 +1,7 @@
 import urllib.parse
 import requests
 from . import common
+from ..lib import log_response
 
 try:
     rackspace_dependencies = True
@@ -38,7 +39,7 @@ class RackspaceDns(common.BaseDns):
             raise ValueError(
                 "Error getting token and URL details from rackspace identity server: status_code={status_code} response={response}".format(
                     status_code=find_rackspace_api_details_response.status_code,
-                    response=self.log_response(find_rackspace_api_details_response),
+                    response=log_response(find_rackspace_api_details_response),
                 )
             )
         data = find_rackspace_api_details_response.json()
@@ -90,7 +91,7 @@ class RackspaceDns(common.BaseDns):
             raise ValueError(
                 "Error getting rackspace dns domain info: status_code={status_code} response={response}".format(
                     status_code=find_dns_zone_id_response.status_code,
-                    response=self.log_response(find_dns_zone_id_response),
+                    response=log_response(find_dns_zone_id_response),
                 )
             )
         result = find_dns_zone_id_response.json()
@@ -101,7 +102,7 @@ class RackspaceDns(common.BaseDns):
             raise ValueError(
                 "Error finding information for {dns_zone} in dns response data:\n{response_data})".format(
                     dns_zone=self.RACKSPACE_DNS_ZONE,
-                    response_data=self.log_response(find_dns_zone_id_response),
+                    response_data=log_response(find_dns_zone_id_response),
                 )
             )
         dns_zone_id = domain_data["id"]
@@ -124,7 +125,7 @@ class RackspaceDns(common.BaseDns):
                 "Error finding dns records for {dns_zone}: status_code={status_code} response={response}".format(
                     dns_zone=self.RACKSPACE_DNS_ZONE,
                     status_code=find_dns_record_id_response.status_code,
-                    response=self.log_response(find_dns_record_id_response),
+                    response=log_response(find_dns_record_id_response),
                 )
             )
         records = find_dns_record_id_response.json()["records"]
@@ -136,7 +137,7 @@ class RackspaceDns(common.BaseDns):
                 "Couldn't find record with name {domain_name}\ncontaining data: {domain_dns_value}\nin the response data:{response_data}".format(
                     domain_name=domain_name,
                     domain_dns_value=domain_dns_value,
-                    response_data=self.log_response(find_dns_record_id_response),
+                    response_data=log_response(find_dns_record_id_response),
                 )
             )
         record_id = RACKSPACE_RECORD_DATA["id"]
@@ -151,21 +152,21 @@ class RackspaceDns(common.BaseDns):
                 raise ValueError(
                     "Timed out polling callbackurl for dns record status.  Last status_code={status_code} last response={response}".format(
                         status_code=callback_url_response.status_code,
-                        response=self.log_response(callback_url_response),
+                        response=log_response(callback_url_response),
                     )
                 )
             if callback_url_response.status_code != 200:
                 raise Exception(
                     "Could not get dns record status from callback url.  Status code ={status_code}. response={response}".format(
                         status_code=callback_url_response.status_code,
-                        response=self.log_response(callback_url_response),
+                        response=log_response(callback_url_response),
                     )
                 )
             if callback_url_response.json()["status"] == "ERROR":
                 raise Exception(
                     "Error in creating/deleting dns record: status_Code={status_code}. response={response}".format(
                         status_code=callback_url_response.status_code,
-                        response=self.log_response(callback_url_response),
+                        response=log_response(callback_url_response),
                     )
                 )
             if callback_url_response.json()["status"] == "COMPLETED":
@@ -196,7 +197,7 @@ class RackspaceDns(common.BaseDns):
                     response=create_rackspace_dns_record_response.text,
                 )
             )
-            # response=self.log_response(create_rackspace_dns_record_response)))
+            # response=log_response(create_rackspace_dns_record_response)))
             # After posting the dns record we want created, the response gives us a url to check that will
         # update when the job is done
         callback_url = create_rackspace_dns_record_response.json()["callbackUrl"]
@@ -225,7 +226,7 @@ class RackspaceDns(common.BaseDns):
             raise ValueError(
                 "Error deleting rackspace dns record: status_code={status_code} response={response}".format(
                     status_code=delete_dns_record_response.status_code,
-                    response=self.log_response(delete_dns_record_response),
+                    response=log_response(delete_dns_record_response),
                 )
             )
         callback_url = delete_dns_record_response.json()["callbackUrl"]

--- a/sewer/lib.py
+++ b/sewer/lib.py
@@ -2,6 +2,17 @@ import base64
 from typing import Union
 
 
+def log_response(response) -> str:
+    """
+    renders a python-requests response as json or as a string
+    """
+    try:
+        log_body = response.json()
+    except ValueError:
+        log_body = response.content[:40]
+    return log_body
+
+
 def safe_base64(un_encoded_data: Union[str, bytes]) -> str:
     "return ACME-safe base64 encoding of un_encoded_data"
 


### PR DESCRIPTION
Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to sewer, and sewer agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that sewer shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.

Pulled duplicated log_response method out as standalone function.  @AlecTroemel was right, this makes a good place to start the unified auth work, it just wasn't obvious obvious to me at the time!
