### PR TITLE
Small cleanups.new working demo driver, lots of docs (not complete)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ the many changes in this release.
 - Support for SAN certificates.
 - Supports wildcard certificates.
 - Bundling certificates.
-- Supports [DNS](#dns-services-supported) and HTTP challenges.
+- Supports [DNS](dns-01) and HTTP challenges.
 - [Bring your own dns provider](#bring-your-own-dns-provider)
 - [Bring your own http provider](#bring-your-own-http-provider)
 - sewer is both a [command-line program](#cli) and a [Python library](#usage) for customization
@@ -257,11 +257,9 @@ The certificate, certificate key and account key will be saved in the directory
 that you run sewer from.
 
 ## Bring your own DNS provider          
-NB: This section is out of date.  It describes the Legacy DNS interface.
-Newer documentation, though not a worked example like this, can be found in
-the docs directory.
+>NB: This section is out of date.  It describes the Legacy DNS interface.
+>Newer documentation can be found in[docs/dns-01](docs/dns-01.md).
 
----
 It is very easy to use any dns provider with sewer.          
 All you have to do is create your own dns class that is a child class of [`sewer.BaseDns`](https://github.com/komuw/sewer/blob/master/sewer/dns_providers/common.py) and then implement the             
 `create_dns_record` and `delete_dns_record` methods.                     

--- a/docs/ACME.md
+++ b/docs/ACME.md
@@ -1,0 +1,48 @@
+## ACME, RFCs, and confusion, oh my!
+
+ACME grew out of early, ad-hoc procedures designed to let CAs issue large
+numbers of certificates with low overhead.  As described in RFC855, these
+would go something like this:
+
+> * Generate a PKCS#10 [RFC2986] Certificate Signing Request (CSR).
+> * Cut and paste the CSR into a CA's web page.
+> * Prove ownership of the domain(s) in the CSR by one of the following methods:
+>     + Put a CA-provided challenge at a specific place on the web server
+>     + Put a CA-provided challenge in a DNS record corresponding to the target domain
+>     + Receive a CA-provided challenge at (hopefully) an administrator-controlled email 
+>       address corresponding to the domain, and then respond to it on the CA's web page
+> * Download the issued certificate and install it on the user's web server
+>
+> With the exception of the CSR itself and the certificates that are
+> issued, these are all completely ad hoc procedures and are
+> accomplished by getting the human user to follow interactive natural
+> language instructions from the CA rather than by machine-implemented
+> published protocols.
+
+HTTP validation was the first mechanism, matching the first method of
+proving ownership in the above.  The rest of what
+[Let's Encrypt](https://letsencrypt.org)
+added was automating the process (and rearranging it a bit, having the proof
+of control happen before the CSR, etc.).  Years later, the IETF standardized
+the ACME protocol, and there are other variants that have been (or will be)
+standardized.
+
+## RFC8555
+
+The [IETF](https://www.ietf.org/) accepted(?) and published
+[RFC8555](https://tools.ietf.org/html/rfc8555) defining the ACME protocol
+for http-01 and dns-01 validations of dns-name authorizations.  These are
+the sort of ACME authorizations that we usually think of, and which sewer
+works with.  The RFC was published in the spring of 2019, but it wasn't
+until near the end of that year that Let's Encrypt adopted the full v.2 on
+only their *staging* server.  There's some elaborate and, from what I can
+make out, often-shifting schedule for various partial transitions, but I'm
+not going to try to make sense of them.  As of the beginning of 2020, the
+only immediate effect on sewer was that one could no longer run it against
+the *staging* server.  The next big change is when that same restriction is
+rolled out on LE's *production* server late in the year.  Since sewer
+v0.8.2, which implemented the final RFC8555 protocol at least well enough to
+work with LE's server implementation, our tl;dr is just this:
+
+> If you get a failure running an older version of sewer, get v0.8.2 or
+> later.  This is a known problem: v0.8.2 is the fix.

--- a/docs/Aliasing.md
+++ b/docs/Aliasing.md
@@ -1,0 +1,91 @@
+# Aliasing for ACME Validation
+
+The idea is presented (for dns-01 authorizations) in [an article at
+letsencrypt.org](https://letsencrypt.org/2019/10/09/onboarding-your-customers-with-lets-encrypt-and-acme.html)
+which shows an example of DNS aliasing
+and describes what was likely the original motivation - a hosting provider
+running the certificate process on behalf of his customers.
+Like all DNS aliasing, it uses a CNAME at the canonical name
+`_acme-challenge.domain.tld` to redirect the ACME server to a different fqdn
+that is more convenient for provisioning of the validation responses.
+I'm not going to try to convince you that you should use aliasing, because
+if you need it you probably already know that, or at least know that the
+process isn't working smoothly as-is.
+
+The `alias` option in sewer is available to drivers that derive from
+`DNSProviderBase`.
+
+**NB: neither drivers nor the cli app have support for `alias` in 0.8.2**
+
+## Isn't aliasing just for DNS?
+
+No.  HTTP has had, as a side effect of common web server and client behavior,
+a kind of aliasing since the very beginning of ACME.  Usually it's
+convenient enough to provision the validation at the canonical
+`/.well-known/acme-challenge/<token>` location.  But if it isn't, either
+`acme-challenge` or `.well-known` can be mapped (by server configuration or
+externally by symlink, usually) to some other location.  If it's desired to
+serve the validation file from some other domain or server altogether, an
+HTTP redirect can often be used (and that's also a third way to place the
+file elsewhere within the web server's accesible filesystem).
+
+The RFC says that (for http-01 challenges) the ACME server "SHOULD follow
+redirects", which would allow for an analogous aliasing.  Lets' Encrypt's
+servers [do follow redirects and
+CNAMES](https://letsencrypt.org/docs/challenge-types/).
+
+So aliasing can be used with HTTP validations, though it's probably less
+often needed since the privilege needed to directly configure the canonical
+response file is likely to be the same (or even less) than that needed to
+setup the new certificate.  And it's possible that you've already used it
+without thinking of it as _aliasing_ because it uses such basic HTTP
+behavior.
+
+## Preparing for DNS aliasing
+
+The first thing which you must have is a way to manage DNS TXT records.  In
+fact, you need to be able to control both the real domain's records (in
+order to setup the CNAME entries, but that's something that needs be done
+only once) as well as managing the alias domain records through the
+service-specific driver.  Generally, expect to need a new-model driver
+rather than an existing legacy driver, on the assumption that it's not much
+more work to migrate the legacy driver to the new interface while adding the
+alias support.  I have my fingers crossed, at any rate...
+
+With alias-capable driver in hand, you then setup CNAME records for every
+DNS name that you wish to use with the alias domain.  In traditional zone
+file form that might look something like this [excerpt]:
+
+    ; existing record for your web or other server
+    name.example.com.                  IN  A     111.222.333.444
+
+    ; the added CNAME at the ACME-prefixed name
+    _acme-challenge.name.example.com.  IN  CNAME name.example.com.alias.org
+
+In online domain editors, the names are usually given without the full
+domain suffix that's shown here (example.com).  The A record (or it could be
+a CNAME) for `name.example.com` that directs to your server is shown as an
+example here.
+The added CNAME record is the redirect from the conventional ACME challenge
+DNS name, pointing to the TXT record in the alias domain.  When it sees that
+CNAME, the ACME server will proceed to look for the challenge's TXT record
+at `name.example.com.alias.org`.  Since the alias-aware driver will have
+setup that TXT record, the server will retrieve it and validate your right
+to issue for `name.example.com`.
+
+Note that the alias domain can be ANY valid domain that you can manage.  In
+particular, it can be in a different tld (as shown here) or a different
+domain in the same tld, or even in a sub-domain (eg. 
+`validation.example.com`) of the target's domain that has been delgated to
+that more convenient DNS server.  And you can setup aliased TXT challenge
+records for names from any number of _real_ domains as long as the CNAME
+redirects can be provisioned.
+
+## Using DNS aliases in sewer
+
+This is really pretty short & sweet.
+All that's needed, once the setup is done, is to pass `alias=alias.org` to
+the alias-supporting driver when it's created.
+For users of the command line tool, you would add an option `--alias
+alias.org` as well as specifying a DNS driver that supports the alias
+method.

--- a/docs/DNS-Propagation.md
+++ b/docs/DNS-Propagation.md
@@ -1,0 +1,99 @@
+## Waiting for Mr. DNS or Someone Like Him
+
+Q: How long does it take after you've setup the challenge response TXT records
+until they're actually accessible to the ACME server?
+
+Good Question!
+
+According to [Let's Encrypt](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge)
+it can take up to an hour.  Depends on the DNS service.  Some provide a way
+to check that your changes are fully propagated to all their servers.  With
+many, however, you just have to wait.
+
+Sewer provides a flexible _delay until actually published_ mechanism through
+three optional driver parameters, `prop_delay`, prop_timeout`,
+`prop_sleep_times`, and the [unpropagated()method](unpropagated).
+Let's see how they're used in various circumstances.
+
+### No API support, no reliable way to check: just delay
+
+If you can't check that the TXT records are fully published, then all you
+can do is delay for a while.  Perhaps the DNS service will suggest a safe
+time.  If not, you'll have to start with a guess and adjust from there based
+on your experience.  Choosing the right number - long enough but not
+excessively long - can be hard, but applying it is easy.  Just add
+`prop_delay=SIMPLE_DELAY_TIME` to the driver's initialization parameters,
+and sewer's engine will add that many seconds of delay after the challenge
+setup returns before it signals the ACME server to validate those
+challenges.
+_[how does this work in the CLI?  TBD!]_
+
+### API support or can check: use a timeout
+
+If the DNS service gives you a way to check that the propagation is
+complete, or if there are not too many authoritative servers (viz., not an
+anycast system), you can use that actual check (implemented in the driver's
+`unpropagated` method) and the engine will run that check until it succeeds
+or until a timeout you specify is exceeded.  However the check is being
+done, you setup the timeout by adding `prop_timeout=MAX_WAIT_TIME` to the
+driver parameters.  If you know that it takes at least some minimum time to
+propagate, you may also pass `prop_delay` to make the engine delay that long
+before it starts checking.  And there's a delay between checks that has a
+hopefully sensible default, but which you can adjust if necessary through
+the `prop_sleep_times` parameter.
+
+### You probably don't need to change `prop_sleep_times`
+
+Unless you do, but if it's not obvious, just leave it.
+
+This parameter defines the lengths of sleeps the engine will add following a
+call to `unpropagated` that reports not ready.  As an optional parameter
+passed to the driver, `prop_sleep_times` can be an integer number of seconds
+or a list or tuple of such delays which will be used in order.  The final
+value in the sequence will be reused indefinitely.
+
+Example: the default value is (1, 2, 4, 8) which provides an exponential
+backoff up to an 8 second delay, then sticks there.  _[the values could
+change - it's just what seemed reasonable to me]_  So if there's no delay,
+and the check call takes no measurable time (and reports not ready each
+time), it will look something like this with `prop_timeout=20`:
+
+| time | action |
+| ---: | --- |
+| 0 | call unpropagated, sleep(1) |
+| 1 | call unproagagted, sleep(2) |
+| 2 | call unpropagated, sleep(4) |
+| 6 | call unpropagated, sleep(8) |
+| 14 | call unpropagated, sleep(8) |
+| 22 | call unpropagated, timeout! |
+
+This shows both the last value repeating and the way the timeout and sleeps
+interact.  The check for timeout is done only AFTER a call to unpropagated
+AND the chance to exit with success if it finally reports the challenges are
+ready.  So the timeout isn't a hard maximum time, but it's bounded to be no
+more than one sleep interval (plus actual time to run `unpropagated`, of
+course) over `prop_timeout`.
+
+### Other Notes and Advanced Use
+
+These values are setup through the Provider on the reasonable assumption
+that they will vary most directly with the choice of service provider, so
+the individual drivers are best suited to provide sensible defaults. 
+Sewer's engine implements the delay and check loop (with timeout) because
+the mechanism is the same for all providers (and may be useful for other
+than the DNS-based challenges for which it has been implemented).
+
+If you are using sewer as a library and find that you can make a better
+estimate of the propagation after the driver is setup (perhaps using a
+service-specific method to access part of the service's API or run some
+tests), you could adjust those parameters through the same-named attributes
+on the Provider instance.  This is solidly in the categories of don't do it
+unless you're sure you need to, and be prepared to own both the pieces if
+you break it!
+
+### Could this be used with non-DNS Providers?
+
+Yes!  I have no experience with http-01 in any setting where such a delay
+might be needed, but the mechanism is implemented in sewer's engine, and all
+that needs be done is to setup the parameters (and unpropagated if using
+more than just `prop_delay`) as described above and there you go!

--- a/docs/LegacyDNS.md
+++ b/docs/LegacyDNS.md
@@ -2,8 +2,8 @@
 
 ### `BaseDns` shim class
 
-A child of `ProviderBase` that acts as an adapter between the Provider
-interface and the Legacy DNS providers.
+A child of `DNSProviderBase` that acts as an adapter between the Provider
+interface and the Legacy DNS provider interface.
 
 #### `__init__(self, **kwargs: Any) -> None`
 
@@ -12,20 +12,20 @@ Injects chal_types=["dns-01"].
 
 #### `setup(self, challenges: Sequence[Dict[str, str]]) -> Sequence[Dict[str, str]]`
 
-Iterates over the challenges, extracting the values needed for dns-01 from
-each challenge in the list, and passing them to create_dns_record.
-Always returns an empty list since there is no error return from
-create_dns_record other than raising an exception.
+Iterates over the challenges, extracting the values needed for the Legacy
+DNS interface from each challenge in the list, and passing them to
+`create_dns_record`.  Always returns an empty list since there is no error
+return from `create_dns_record` other than raising an exception.
 
 #### `unpropagated(self, challenges: Sequence[Dict[str, str]]) -> Sequence[Dict[str, str]]`
 
 Always returns an empty list, signalling "all ready as far as I know".
-A DNS provider wishing to do something useful here must migrate to the new
-API.
+A Legacy DNS provider wishing to do something useful here MAY implement
+`unpropagated` without migrating the rest of its interface.
 
 #### `clear(self, challenges: Sequence[Dict[str, str]]) -> Sequence[Dict[str, str]]`
 
-Same as setup except it calls the legacy delete_dns_record, of course.
+Same as setup except it calls the legacy `delete_dns_record`, of course.
 
 ### Legacy DNS class
 
@@ -33,7 +33,7 @@ Same as setup except it calls the legacy delete_dns_record, of course.
 
 Args are explicitly named per provider; no provision for passing any to
 `super().__init__` - which makes sense, since there used not to be any the
-parent was prepared to receive.
+parent (original `BaseDns`) was prepared to receive.
 
 #### `def create_dns_record(self, domain_name, domain_dns_value)`
 
@@ -45,4 +45,11 @@ All very provider-dependent.
 
 In theory it should undo the effects of setup.
 In practice, at least one of the services is unable to do that
-(according to the comment).
+(according to the author's comment).
+
+### Legacy DNS vs Aliasing
+
+Legacy DNS providers MAY adapt to using the [aliasing](DNS-ALiasing), though
+a potentially fragile faking of the new-model challenge dict is required. 
+See the `unbound_ssh` example driver, and bear in mind that a change to the
+data type of the challenge items IS anticipated, perhaps in 0.9.

--- a/docs/UnifiedProvider.md
+++ b/docs/UnifiedProvider.md
@@ -1,7 +1,8 @@
 ## DNS and HTTP challenges unified
 
-*DRAFT VERSION*  May 31st 2020 - prop_delay added.  Was: file name changed; stub challenge-specific
-bases added.
+*DRAFT VERSION*  Jun 16th 2020 - reference DNS-Propagation, Was: prop_delay added.
+
+### Dedication
 
 It is indisputable that this is, in the first instance, Alec Troemel's fault,
 since he added support for http-01 challenges.
@@ -11,39 +12,28 @@ while influenced by Alec's code and our discussions,
 are entirely my fault.
 Alec cannot be blamed for my choices!
 
-_Because the word "provider" is so overloaded, I'm going to refer to the
+### A few words about words
+
+Because the word "provider" is so overloaded, I'm going to refer to the
 service-specific implementations as "drivers", except when I forget, or
-overlooked an old usage.  "Provider" is still used in the class names.  And
+missed changing an old use.  "Provider" is still used in the class names.  And
 then there are the "service providers", viz., DNS services or web hosts,
-etc._
+etc.
+
+### Overview (tl;dr)
 
 `ProviderBase` described here defines the interface the ACME engine uses
 with new-model drivers (all http-01 drivers, as there are no old ones).  New
-drivers should inherit from the `DNSProviderBase` or `HTTPProviderBase`
-classes in auth.py.  At this time the only functioanlity these add is
-setting up the `chal_types` parameter, and for DNS collecting the not yet
-implemented `alias` parameter.
+drivers normally should inherit from the `DNSProviderBase` or
+`HTTPProviderBase` classes in auth.py.  _(for those who watched the
+unification, no, this isn't really dividing them back up - they still have
+the identical interface defined in `ProviderBase`.  But there are
+unavoidable implementation differences, and once `DNSProviderBase` was added
+to anchor the aliasing suport, it just seemed prudent to put
+`HTTPProviderBase` there as a hedge against future need.)_
 
-> For the alias feature, there are several moving parts, some optional.
-I would like to support checking that the CNAMEs are provisioned.
-Currently that requires adding a dependency (probably dnspython?),
-but that may be necessary anyway for implementing unpropagated.
-The ~~engine~~ `DNSProviderBase` class can compose the names for the CNAME
-record as well as the alias record, and if doing the full checking it may need
-to do so, so I ~~am considering~~ have added `DNSProviderBase` with an
-optional `alias` parameter and simple methods to turn a challenge's domain
-into the fqdn of the CNAME (if there is one) and the target where the
-challenge response will be placed.  Brand new and subject to change...
-
-> Also just added `HTTPProviderBase` which hasn't acquired any interesting
-features yet, and may never do so, but it seems a tiny cost to prevent the
-disruption its absence could result in at some later date.
-
-All the existing DNS drivers were written to the legacy interface, and are
-supported through a shim class in dns_providers.common, `BaseDns`.  These
-legacy implementations will, hopefully, be migrated to the new-model
-interface.  The assistance of the authors and/or current users of each
-driver will be needed!
+sewer has support for [aliasing](docs/Aliasing), though drivers need to
+be created (or modified) to support it at this time.
 
 ### ProviderBase interface for ACME engine
 
@@ -51,6 +41,8 @@ The interface between the ACME protocol code and any driver implementation
 consists of three methods, `setup`, `unpropagated` and `clear`.  The first
 and last are not unlike methods used by the legacy drivers, but they accept
 a list of one or more challenges rather than one challenge at a time.
+
+--- most of this is in [unpropagated], or should be.  ToDo: reconcile
 
 The `unpropagated` method was added with DNS propagation delays in mind.  It
 should be possible for legacy drivers to implement this without a full
@@ -63,15 +55,15 @@ validated.  This should be more reliable than adding an ad-hoc delay before
 _responding_ to the ACME server as well as avoiding wasting time.
 
 The errata list returned by by all three methods has tuples for elements,
-where each tuple holds three values: the status, the msg, and the original,
-unmodified challenge item (dictionary).  _Recent change, may not have fixed
-all other ideas in code or docs yet._
+where each tuple holds three values: the status string, the msg string, and
+the original, unmodified challenge item (dictionary).  This is defined as
+types `ErrataItemType` and `ErrataListType` in auth.py
 
-> LE's ACME server, for one, implements neither automatic nor
-triggered retries, so it's important not to _respond_ to a challenge before
-the validation response is actually accessible.  And yes, the RFC's language
+> LE's ACME server, for one, implements neither automatic nor triggered
+retries, so it's important not to _respond_ to a challenge before the
+validation response is actually accessible.  And yes, the RFC's language
 does encourage confusing the respond-to-challenge API request with the
-validation response that the server has to get when it probes for it.
+challenge response (TXT) that the server has to find when it probes for it.
 
 > My thinking on this is that, while the ACME engine's code can know what
 names to check, in the really interesting case of widely distributed
@@ -81,6 +73,8 @@ API for checking some internal status that might be faster and/or more
 reliable than polling DNS servers.  For cases where all that can (or needs)
 to be done is some DNS lookups, well, that can be packaged as a function.
 
+--- end reconcile block
+
 This is the pattern which all three methods use: accept a list of challenges
 (each a dictionary) to process, and return an errata list containing the
 subset which have problems or are not ready.  So in all cases an empty list
@@ -88,39 +82,50 @@ returned means that all went well.
 
 ### `ProviderBase`
 
-Abstract base class for driver implementations to inherit from.  There is
-also a child class, `BaseDns` that the legacy drivers are based on which
-shims their old DNS-only interface.
+Abstract base class for driver implementations ultimately inherit from.
 
-#### `__init__(self, **kwargs: Any) -> None`
+#### ProviderBase __init__
 
-All native driver classes take only `**kwargs` parameters.  Derived classes
-MUST extract the parameters they recognize and process them, which includes
-raising an exception for missing required values, etc.  They MUST ignore
-names they don't recognize and pass them along to `super()__init__`.  They
-MAY add or modify parameters before passing the parameters to their
-parent's` __init__`.
+    __init__(self,
+        *,
+        chal_types: Sequence[str],
+        logger: Optional[LoggerType] = None,
+        LOG_LEVEL: Optional[str] = "INFO",
+        alias: Optional[str] = None,
+        prop_delay: int = 0
+        prop_timeout: int = 0,
+        prop_sleep_times: Union[Sequence[int], int] = (1, 2, 4, 8)
+    ) -> None:
 
-`ProviderBase` differs only in that unrecognized parameters, viz., any that
-are left after its own known parameters are extracted, are reported as an
-error.  The parameters which `ProviderBase` will recognize are:
 
-| name |status | value type | description |
-| --- | --- | --- | --- |
-| chal_types | REQUIRED | `Sequence[str]` | The ACME challenge types the child class can satisfy. |
-| logger | REQ 1 of 2 | `str` | A configured logging object to use by the driver |
-| LOG_LEVEL | REQ 2 of 2 | `Union[str, int]` | Old way to setup logging. Only one of logger and LOG_LEVEL can be used |
-| prop_delay | OPTIONAL | int | If passed, then wait up to this long for unpropagated eratta list to clear.  Default is no delay. |
+The drivers' `__init__` methods accept only keyword arguments.  Here we see
+that ProviderBase has become the final recipient of quite a few, mostly
+optional, arguments.  This is the general form that Provider subclasses are
+expected to follow: explicitly list the arguments which that driver requires
+after the *, so they must be passed as keyword args, but give no default
+value so that they will be diagnosed as missing by the call protocol.
 
-> This morning's ah-ha moment was in two closely spaced parts.  Imprimis,
-that the wait time for propagation OUGHT to come from the driver, since
-that's where [DNS or other] service-specific info belongs.  Oh, and
-prop_delay is a good name for the driver attribute.  And default is None ->
-no delay -> no call to check.  Secundus, that this SHOULD be collected all
-the way at the top, in `ProviderBase` to insure there is always a prop_delay
-attribute because that delay is now an internal protocol parameter.  And
-even though I can't see why, now, it could be needed for other challenge
-types.
+Conveniently, ProviderBase's __init__ has instance of all the variations.
+chal_types is required, so it has no default value and will be diagnosed by
+Python itself.  logger/LOG_LEVEL are... weird.  Without the legacy DNS
+providers I would be inclined to just require logger, pushing the job of
+setting up logging firmly back up the stack.  As it is, logger cannot be
+required (yet), so both have defaults that work with the __init__ logic to
+setup logging as sanely as possible.  Eventually LOG_LEVEL should get
+deprecated and then dropped, and logger is just required...
+
+alias and the prop_* arguments are all optional, and have default values
+that the engine code is designed to deal with - by disabling the optional
+behavior they control.  These are all parameters that were introduced for a
+lower-level driver or driverBase class, but which have migrated up to
+ProviderBase because they may apply to any sort of Provider.
+
+In all child classes, kwargs is expected to catch parameters that may need
+to pass up the Provider classes, and so it must be passed to
+super()__init__.  It is allowed to add, change, or even remove items from
+kwargs if necessary - see the intermediate *ProviderBase classes.
+
+--- (see where for args documentation?  DNS-Alias and DNS-Propagation & ???)
 
 #### `setup(self, challenges: Sequence[Dict[str, str]]) -> Sequence[Tuple[str, str, Dict[str, str]]]`
 

--- a/docs/dns-01.md
+++ b/docs/dns-01.md
@@ -1,0 +1,72 @@
+## sewer's DNS service support
+
+ACME's dns-01 authorization was sewer's original target.
+There are a number of DNS services supported in-tree,
+and implementations for other services are difficult to write only if the
+service's API is difficult.
+
+## DNS services supported
+
+- [acme-dns](https://github.com/joohoi/acme-dns)
+- [Aliyun](https://help.aliyun.com/document_detail/29739.html)
+- [Aurora](https://www.pcextreme.com/aurora/dns)
+- [AWS Route 53](https://aws.amazon.com/route53/)
+- [Cloudflare](https://www.cloudflare.com/dns)
+- [ClouDNS](https://www.cloudns.net)
+- [DNSPod](https://www.dnspod.cn/)
+- [DuckDNS](https://www.duckdns.org/)
+- [Gandi](https://doc.livedns.gandi.net/)
+- [Hurricane Electric DNS](https://dns.he.net/)
+- [PowerDNS](https://doc.powerdns.com/authoritative/http-api/index.html)
+- [Rackspace](https://www.rackspace.com/cloud/dns)
+
+## Add a driver for your DNS service
+
+sewer's [legacy DNS driver interface](LegacyDNS) (BaseDns in dns_providers/common.py)
+is deprecated, although there is no schedule for its removal at this time.
+These legacy drivers should be migrated to the new DNSProviderBase (in
+auth.py) when practical.  New DNS drivers should use DNSProviderBase from
+the start, of course, and will be placed in sewer/providers/ if added to the
+project.
+
+    # sketch of dns-01 provider, including alias support
+
+    from ..auth import DNSProviderBase
+    from ..lib import dns_challenge
+
+    class Provider(DNSProviderBase):
+        def __init__(self, *, my_api_url, my_api_id, my_api_key, **kwargs):
+	    super().__init__(self, **kwargs)
+            self.api_url = my_api_url
+            self.api_id = my_api_id
+            self.api_key = my_api_key
+
+        def setup(self, challenges):
+	    for challenge in challenges:
+                fqdn = self.target_domain(challenge)
+                txt_value = dns_challenge(challenge["key_auth"])
+                self.my_api_add_txt(fqdn, txt_value)
+
+        def unpropagated(self, challenges):
+            return []  # if service has a propagation check, use it here
+
+        def clear(self, challenges):
+            # like setup, but calling my_api_del_txt; may not need txt_value
+
+        def my_api_add_txt(self, fqdn, txt_value):
+            # this is where you talk to the DNS service to add a TXT
+
+        def my_api_del_txt(self, fqdn):
+            # talk to DNS service to remove TXT
+
+Most of your work is in implementing the two methods which actually
+communicate with the DNS service.  This can be easy or very difficult,
+depending on the service provider's API (or lack of designed API if you have
+to use a mix of web scraping and HTTP request generation to operate a
+mechanism that was designed for interactive use).
+
+The above is bare-bones, not taking advantage of the batching of challenges
+which the new-model interface provides - that can be huge if you have to
+grovel the service's API (or web pages) to guide the construction of your
+commands to them.  It does show the use of target_domain to support
+[DNS aliasing](Aliasing).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,39 @@
+## sewer, the ACME library and command-line client
+
+A quick guide to the docs directory.
+NB: much of this was written to document what I'd just done,
+and as you might expect that led to quite a few _oh bother, that's not the
+right way to do it_ moments.
+After which sometimes the docs got revised and then the code;
+other times the other way around; and these could iterate.
+
+And sometimes the docs proved to be wrongly named, or split into parts.
+
+And none of this is **done** changing yet.
+
+- [UnifiedProvider.md](UnifiedProvider) was the first intentional thought
+  doc.  It has been written and revised repeatedly since Alec's original
+  http-01 changes got me thinking about how best to accomodate both, as well
+  as other validation methods that were already RFCs or on their way.
+- [unpropagated.md](unpropagated) was the first separate piece.  Begun as I was
+  figuring out what to do, and changes upon changes here as well.  Heading
+  towards being documentation of the implementation.
+- [DNS-Propagation.md](DNS-Propagation) has become (is becoming?) the document
+  about _what_ propagation means to the ACME process and _how_ we might
+  manage it.  From the title you can tell it began when I was still thinking
+  of propagation as DNS thing.
+- [Aliasing.md](Aliasing), just renamed from DNS-Aliasing, so the contents must
+  still be in flux, too.  Probably a lumpy blending of implementation and
+  user notes, still.
+- [ACME.md](ACME) A bit of history, a start on a technical essay, or ??? 
+  Notes on various things related to ACME and Let's Encrypt's servers.
+- [LegacyDNS.md](LegacyDNS) Documents the new-model shim (still named
+  BaseDNS) that allows unmigrated Legacy DNS drivers to continue working. 
+  Authors of any DNS module, Legacy or new, should review this... and,
+  hopefully, migrate to or start anew as new-model Providers.
+- [wildcards.md](wildcards) Notes about wildcard certificates - they should
+  work for all drivers now! - and a special case where there are probably
+  still issues.
+
+And an even less stable (because it hasn't been coded yet!) peek at
+something I'm calling [cloaca](preview/cloaca) for now.

--- a/docs/preview/cloaca.md
+++ b/docs/preview/cloaca.md
@@ -1,0 +1,52 @@
+# Cloaca, aka sewer-cli-next?
+
+_This is so preliminary that it hasn't been written yet.  A design essay in
+a rambling style is all it is._
+
+The design of the sewer-cli program is focused on getting one certificate
+with no state (aside from the optionally reused account key) on disk.  I can
+say from much personal experience that this is wonderful for doing ad-hoc
+tests while changing the implementation, and it's workable even for getting
+a handful of certificates (ah, shell script, how I both love and hate
+thee...), but I've long thought about a better way - better, at least, for
+how I'd like to handle certificate renewal.
+
+## Shortcomings of sewer-cli
+
+One thing that I kept tripping on was the apparent lack of a simple way to
+setup a new account key for later use.  And strictly speaking, sewer-cli
+just doesn't do that.  Enlightenment comes when you give proper
+consideration to sewer-cli's scope - it gets only one certificate per
+invocation, so you can harvest the one it created and reuse it later.  I
+missed that because I was already looking to get several (three, IIRC)
+certificates when I first started using sewer.
+
+The other "issues" that come to mind are just limitations of the intended
+scope of sewer-cli.  As mentioned above, I ended up doing some shell
+scripting to work around _all those --options, some the same and some that
+change for each certificate_.  And the other part I wanted to automate (and
+felt less happy doing in a shell script for $REASONS) was getting the new
+certificates installed after they were created.
+
+So cloaca addresses these.
+
+## The cloaca command
+
+First change - the cloaca command takes, as its first, required, non-option
+argument, the sub-command which selects the operation to carry out.  The
+short list so far goes like this:
+
+- account - create key, register, deregister, maybe transfer, others
+- renew - with no options, renew & install (if configured) all certs in cloaca.ini
+
+And more to come.  Plenty of operations are defined in RFC8555 which never
+got into sewer-cli.  Goal will be to support all the operations in the RFC
+that Let's Encrypt has implemented.
+
+Second change - cloaca is more [config-driven](cloaca_config) than
+--option-driven.  Which doesn't mean options won't be available, but maybe
+not to the point of emulating sewer-cli's ability to renew one certificate
+without any configuration.
+
+_Okay, that's it for now.  Need to get some proof of concept code to see if
+any of the untested ideas are more problematic than I believe._

--- a/docs/preview/cloaca_config.md
+++ b/docs/preview/cloaca_config.md
@@ -1,0 +1,134 @@
+# Configuration file for cloaca
+
+_This is a pre-coding, let alone release, preview of a more config-driven
+user command that's just starting to bubble in the crock pot here.  It could
+end up being cli-next if it's practical to combine the two different
+approaches in one.  Either way, it needs a less awkward name than cli-next. :-)_
+
+Cloaca's configuration has been driven by a couple use cases.  If you have
+only a single certificate, for one or a few identities (SANs), the
+traditional option-driven CLI program is perhaps easier.  Cloaca is designed
+for the case where several certificates are being managed together.  It also
+adds installation support to get those certificates onto the servers. 
+Somewhat to my surprise, it has ended up using the simple "ini" file format.
+
+## Introductory examples
+
+A minimal configuration for one certificate for test.example.com that just
+leaves test.example.com.key and test.example.com.key sitting in the current
+working directory:
+
+    [cert_test.example.com]
+    account_email = webmaster@example.com
+    provider = demo_dns
+
+This demonstrates an important convention: certificate sections are named by
+prepending "cert_" to the domain identity.  The only other data it requires
+to produce a new key and certificate, is the name of the Provider class that
+will handle publishing the challenge responses.  As always, the driver's
+auhtentication parameters are here assumed to be passed in through
+environment variables (but they could be additional items in that section if
+you like).
+
+Now, let's add the promised installation to this example:
+
+    [cert_test.example.com]
+    account_email = webmaster@example.com
+    provider = demo_dns
+    install_transport = ssh
+    install_ssh_to = root@test.example.com
+    install_dir = /etc/apache2/ssl
+    install_post_cmd = system restart apache2
+
+Getting a little longer, and it glosses over how it gets the ssh key it will
+need for the installation.  So what happens when we have multiple
+certificates?
+
+    [cert_default]
+    account_key = account.key
+    account_email = webmaster@example.com
+    provider = demo_dns
+    install_transport = ssh
+    install_dir = /etc/apache2/ssl
+    install_post_cmd = systemctl restart apache2
+
+    [cert_test.example.com]
+    install_ssh_to = root@test.example.com
+
+    [cert_example.com]
+    SAN = www.example.com
+    install_ssh_to = hostmaster@www.example.com
+
+    [cert_webmail.example.com]
+    install_ssh_to = postmaster@webmail.example.com
+    install_dir = /etc/certificates
+    install_post_cmd = systemctl restart dovecot
+
+There's a reason this avoids the native [DEFAULT] section, which we'll come
+back to later.
+
+## Configuration Reference
+
+All of the actual configuration options can appear in a certificate section. 
+A certificate section is any section whose name is formed by prepending
+"cert_" to the principle domain name (CN in certificate speak).  The
+available keys:
+
+- account_key = filepath to account key to use for this certificate
+- account_email = what it says, obviously
+- account_file = filepath to file with account key, email, and other info TBD
+  (this might replace _key and _email, those coming as args to account creation?)
+- provider = name of Provider class
+- provider_KW = value, passed to class constructor as KW=value
+- SAN = san1, san2, ...  comma-separated list of additional identifiers to add to certificate
+- install_transport = name of method to use, eg., ssh, cp, ...
+- install_ssh_to = user@fqdn for any ssh-based transport (also for post_cmd, etc)
+- install_dir = path (should be absolute) to directory where new key & crt are installed
+- install_post_cmd = command to be run after key is installed (to make it take effect)
+
+As seen above, a [cert_default] section will be folded in to every
+[cert_f.q.d.n] section.  This is convenient for truly universal settings,
+but the `_method` mechanism is preferred for setting that apply to a subset
+of all the certificates in a config file.
+
+### The `_method` Method
+
+This allows a goupr of settings that are shared among some of the
+certificates to be grouped and defined once, then included by name.  More or
+less:
+
+    [cert_default]
+    account_key = account.key
+    provider = demo_dns
+
+    [install_apache2]
+    transport = ssh
+    dir = /etc/apache2/ssl
+    post_cmd = systemctl restart apache2
+
+    [cert_test.example.com]
+    install_method = apache2
+    install_ssh_to = root@test.example.com
+
+    [cert_example.com]
+    SAN = www.example.com
+    install_method = apache2
+    install_ssh_to = hostmaster@www.example.com
+
+The mechanism finds keys of the form <PREFIX>_method = <NAME> and looks for
+a section [<PREFIX>_<NAME>].  It then replaces the <PREFIX>_method item with
+the items in that section after prepending <PREFIX>_ to each key.  So in the
+above, each occurence of
+
+    install_method = apache2
+
+is replaced by
+
+    install_transport = ssh
+    dir = /etc/apache2/ssl
+    post_cmd = systemctl restart apache2
+
+Which is much like what a [cert_default] section would do except it wouldn't
+try to add the apache config items into certs that are for an nginx hosted
+domain, say.  The `_method` method only imports the settings it's asked to
+import.

--- a/docs/unpropagated.md
+++ b/docs/unpropagated.md
@@ -1,34 +1,62 @@
-#### `unpropagated` method and intelligent waiting
+# Waiting for the Propagation
 
-The `unpropagated` method provides a hook where the driver MAY check that
-the challenge responses that were configured by `setup` are actually
-accessible to the ACME server.  This is, of necessity, no more than a
-best-effort check, but since LE only attempts to validate a challenge once,
-then marks it invalid if it didn't succeed, it will sometimes be worth
-doing.
+When you use a service provider's API to setup a challenge response, how
+long does it take before the ACME server can reliably get that answer? 
+Especially with global anycast DNS services, it can take a while!  This
+delay between _posted to API_ and _actually online everywhere that matters_
+is the propagation delay we're talking about here.
 
-There are two parameters that are set through the driver's __init__ and used
-by the ACME engine to manage this checking.  The first is `prop_timeout`,
-which must be set to a positive value for `unpropagated` to be called at all. 
-When set, it is the overall timeout in seconds.  This might be set by the
-driver for services that are known to take a while, but if so that value
-SHOULD be overridden by an explicit keyword argument.
+## How shall we wait, let me count the ways
 
-The second parameter is probably less often needed, and has a default that
-ought to be reasonable in most cases.  `prop_sleep_times` is a list of
-seconds to sleep after a failed call to `unpropagated`.  The values are used
-in order, so the default [1, 2, 4, 8] sleeps for 1 second, then 2 seconds,
-then 4 seconds, then 8 seconds every subsequent time.  There's one special
-case: `prop_sleep_times` may be a single integer, which sleeps for that
-fixed delay following every failed check.
+sewer provides two kinds of delay that can be used to deal with propagation
+within the service provider's systems.  Although this was designed mostly
+for DNS validation, it may be needed for other types depending on the
+service provider.  The two kinds of delay are (1) an unconditional sleep and
+(2) an iterative probe/sleep delay loop that has a timeout to keep it from
+waiting _too long_.
 
-The timeout is not quite a hard one: it is checked immediately after a
-failed call to `unpropagated`, and if it has not been exceeded there will be
-a sleep of whatever time followed by another check.  The loop keeps checking
-for AT LEAST `prop_timeout` seconds.
+### To sleep, perchance t'will be enough
 
-Mentioned for completeness: if a driver wishes to just add a fixed delay
-between `setup` and signalling the ACME server to validate the challenges,
-it could implement `unpropagated` as just sleep(delay) and return success (an
-empty errata list).  NB: it still needs a non-zero `prop_timeout` for the
-driver to pass up to `super().__init__`.
+The unconditional sleep is implemented in the sewer core logic and is
+available to any driver which can accept `prop_delay=seconds_to_sleep` and
+pass it up to its base class.  If set to a positive value, it simply invokes
+`sleep(prop_delay)` to wait that number of seconds after the challenges have
+all been setup.
+
+NB: none of the legacy drivers in 0.8.2 have been modified to support
+passing `prop_delay` or other non-specific arguments.
+
+### Check twice, respond once
+
+The iterative probe is a more active sort of delay: it repeatedly calls the
+driver's `unpropagated` method to test whether the challenges are all in
+place.  Sadly, the service providers who most need this kind of check are
+probably the ones it is most difficult to meaningfully test: by design, you
+cannot know which anycast DNS or CDN machine(s) the ACME server will query,
+now which ones you'll get in a simple probe by DNS name.  Some service
+providers may give you a way to query through their API.  Do what you can...
+
+There are two parameters that manage this: `prop_timeout` and the optional
+`prop_sleep_times`.  The first has to be present for the probing to happen
+at all; by default this checking is skipped.  the sleep times is an array of
+integers, with a default value [1, 2, 4, 8] which causes the loop to sleep 1
+second after the first probe if the challenges are not all ready, then 2, 4,
+8, and ever after 8 seconds, continuing until it's been at least
+prop_timeout seconds since the first probe.
+
+This does also require an implementaion of the `unpropagated` method in the
+driver.  The only sane default, used for the unmodified legacy drivers, is
+to always return success without any actual checking.
+
+## Advice to driver authors and users
+
+Authors: If the service gives you a way to do a meaningful check and it's
+needed, please implement `unpropagated`, and mention that in the driver's
+documentation.  Otherwise, just make sure it inherits or implements a null
+check.  Feel free to set default values for delay and/or timeout if its
+predictable enough, but be sure not to overide the values if they're passed
+into the driver.  And document, document, document!
+
+Users: Check those driver docs to see what's supported.  Most of the time, a
+goodly `prop_delay` will get you past the propagation most of the time, and
+is more likely to be available.

--- a/docs/wildcards.md
+++ b/docs/wildcards.md
@@ -1,0 +1,38 @@
+# Wildcard Certificates
+
+Since 0.8.2, sewer should be able to request and receive simple wildcard
+certificates using any of the DNS drivers.  In earlier versions there was an
+odd re-naming of wildcard targets that drivers would, sometimes unreliably,
+remove - tl;dr: before 0.8.2 it depended on the driver.
+
+One issue remains.  Certificates with a wildcard CN name, eg.,
+*.example.com, are valid for all and only the immediate sub domains of
+example.com.  They do NOT validate for the example.com domain itself, which
+may come as a surprise if you have used some other (commercial?) providers,
+as they sometimes just add the naked domain as decsribed below.
+
+The trick is that you use *.example.com as the CN, and add the bare
+example.com as a SAN (in sewer-cli terms: --domain *.example.com
+--alt_domains example.com).  Sewer itself, both through sewer-cli as well as
+the library interface (Client) is fully capable of handling this.  The catch
+is in publishing the challenge response.  To the service-specific driver,
+this will appear as two different TXT values for the same name (naked
+example.com, since there are no wildcards in DNS).  Traditional DNS systems
+(inevitable eg.: bind) have no problem with having multiple TXT records like
+this, but many DNS service providers are using very different software.  To
+be honest, as I don't use any of these myself, so I have no idea if the
+problem some of sewer's drivers have with this are in the service provider's
+core system or just their API layer.  But we have had a problem using those
+APIs when setting up such wildcard-plus-naked-domain certificate's
+validations, and from here on the outside we can only deal with them one by
+one.
+
+> There is a general fix that OUGHT to be possible: have sewer's core logic
+recognize cases where such "duplicate" challenges exist, and if the driver
+doesn't announce itself capable of handling it, use a multi-step process to
+publish some of the challenges, wait for propagation, respond to the ACME
+server, and wait for the challenges to be validated; then repeat the whole
+process for the "duplicate" validation.  For now, my (mmaney) "plan" is to
+continue helping driver authors fix the drivers they're familiar with as a
+bug is reported (and try to talk them into migrating to the new-model
+interface, of course!).

--- a/sewer/dns_providers/common.py
+++ b/sewer/dns_providers/common.py
@@ -1,10 +1,10 @@
 from typing import Any, Dict, Sequence
 
-from sewer.auth import ErrataItemType, ProviderBase
-from sewer.lib import dns_challenge
+from ..auth import ErrataItemType, DNSProviderBase
+from ..lib import dns_challenge
 
 
-class BaseDns(ProviderBase):
+class BaseDns(DNSProviderBase):
     """
     Shim for legacy DNS provider interface.
     """

--- a/sewer/dns_providers/unbound_ssh.py
+++ b/sewer/dns_providers/unbound_ssh.py
@@ -1,0 +1,64 @@
+import subprocess
+
+from .common import BaseDns
+
+
+class UnboundSsh(BaseDns):
+    """
+    Minimal demo of using aliasing with legacy DNS model.
+
+    Usage:
+
+        provider = UnboundSsh(ssh_des="user@fqdn", alias="validation.some.domain")
+        acme = client.Client(domain="host.your.domain", provider=provider, ...)
+        certificate = acme.cert()
+        ...
+    """
+
+    def __init__(self, *, ssh_des, **kwargs):
+        """
+        ssh_des is a REQUIRED keyword option that specifies the "destination"
+        argument for making the SSH connection (see ssh(1)).  It is ASSUMED
+        that the remote login has access to unbound's key so that it can run
+        unbound-control to update the alias zone.
+        """
+
+        super().__init__(**kwargs)
+        self.ssh_des = ssh_des
+
+    def create_dns_record(self, host_fqdn, acme_challenge):
+        self.manage_dns_record(host_fqdn, acme_challenge, "add")
+
+    def delete_dns_record(self, host_fqdn, acme_challenge):
+        self.manage_dns_record(host_fqdn, acme_challenge, "del")
+
+    def manage_dns_record(self, host_fqdn, acme_challenge, cmd):
+        """
+        The first line of code here is really the whole of the aliasing demo - everything
+        else is just the scaffolding to make this work in my [manual] testing environment.
+
+        NB: faking the challenge dict is potentially fragile.  Much better to
+        migrate the legacy DNS driver to the new model if possible!
+        """
+
+        fqdn = self.target_domain({"domain": host_fqdn})
+
+        update_cmd = unbound_command(cmd, fqdn, acme_challenge)
+        print("unbound: %s" % (update_cmd,))
+        res = subprocess.run(("ssh", self.ssh_des, "unbound-control", update_cmd))
+        if res.returncode != 0:
+            raise RuntimeError(
+                "FAILURE (%s): unbound command failed:\n  %s" % (res.returncode, res.args)
+            )
+
+
+# DO # NOT # USE # @classmethod # just to hide the function in the class.  Namespaces are great!
+
+
+def unbound_command(cmd, fqdn, acme_challenge):
+    if cmd == "add":
+        return "local_data %s. 300 IN TXT '%s'" % (fqdn, acme_challenge)
+    if cmd == "del":
+        return "local_data_remove %s." % (fqdn,)
+
+    raise ValueError("Unrecognized command to unbound_command: %s" % (cmd,))

--- a/sewer/lib.py
+++ b/sewer/lib.py
@@ -2,6 +2,8 @@ import base64, logging
 from hashlib import sha256
 from typing import Any, Union
 
+LoggerType = logging.Logger
+
 
 ### FIX ME ### can be more specific about response's type... somehow
 
@@ -17,7 +19,7 @@ def log_response(response: Any) -> str:
     return log_body
 
 
-def create_logger(name: str, log_level: Union[str, int]) -> logging.Logger:
+def create_logger(name: str, log_level: Union[str, int]) -> LoggerType:
     """
     return a logger configured with name and log_level
     """

--- a/sewer/providers/demo.py
+++ b/sewer/providers/demo.py
@@ -1,35 +1,36 @@
 "demo.py - examples of implementing non-or-minimally-functional challenge providers"
 
-###
-### NB: very early draft, minimal testing so far (May 25th)
-###
+# still minimally functional - too handy for testing to make it wait for input
 
-from typing import Any, Dict, Sequence
+from typing import Any
 
-from ..auth import ProviderBase
+from ..auth import ChalListType, ErrataListType, ProviderBase
 from ..dns_providers.common import dns_challenge
 
 
 class ManualProvider(ProviderBase):
-    def __init__(self, **kwargs: Any) -> None:
-        chal_type = kwargs.pop("chal_type", "http-01")
+    def __init__(self, *, chal_type: str = "http-01", **kwargs: Any) -> None:
+
+        ### FIX ME ### poor example ignores possible chal_types in kwargs?
+
+        # this is unusual: it can accept either DNS or HTTP challenges.  Some sanity checks...
         if chal_type not in ["dns-01", "http-01"]:
             raise ValueError("ManualProvider: invalid chal_type value: %s", chal_type)
         kwargs["chal_types"] = [chal_type]
         super().__init__(**kwargs)
         self.chal_type = chal_type
 
-    def setup(self, challenges: Sequence[Dict[str, str]]) -> Sequence[Dict[str, str]]:
+    def setup(self, challenges: ChalListType) -> ErrataListType:
         return self._prompt("add", challenges)
 
-    def unpropagated(self, challenges: Sequence[Dict[str, str]]) -> Sequence[Dict[str, str]]:
+    def unpropagated(self, challenges: ChalListType) -> ErrataListType:
         # could add confirmation here, but it's just a demo
         return []
 
-    def clear(self, challenges: Sequence[Dict[str, str]]) -> Sequence[Dict[str, str]]:
+    def clear(self, challenges: ChalListType) -> ErrataListType:
         return self._prompt("clear", challenges)
 
-    def _prompt(self, mode: str, challenges: Sequence[Dict[str, str]]) -> Sequence[Dict[str, str]]:
+    def _prompt(self, mode: str, challenges: ChalListType) -> ErrataListType:
         for chal in challenges:
             if self.chal_type == "dns-01":
                 print(
@@ -43,4 +44,7 @@ class ManualProvider(ProviderBase):
                         mode, **chal
                     )
                 )
+
+        ### FIX ME ### using this for some tests, so no prompt "press return when setup"
+
         return []

--- a/sewer/tests/test_lib.py
+++ b/sewer/tests/test_lib.py
@@ -1,0 +1,37 @@
+import logging
+import unittest
+
+from .. import lib
+
+
+class response:
+    def __init__(self, *, content_val="", json_val=None):
+        self.content = content_val
+        self._json = json_val
+
+    def json(self):
+        if self._json is None:
+            raise ValueError("No json here")
+        return self._json
+
+
+class TestLib(unittest.TestCase):
+    def test01_log_response_json_okay(self):
+        self.assertEqual(lib.log_response(response(json_val="{}")), "{}")
+
+    def test02_log_response_content_okay(self):
+        self.assertEqual(lib.log_response(response(content_val="{}")), "{}")
+
+    def test11_create_logger_okay(self):
+        logger = lib.create_logger("silly_test_logger", 42)
+        self.assertIsInstance(logger, logging.Logger)
+        self.assertEqual(logger.getEffectiveLevel(), 42)
+        self.assertTrue(logger.hasHandlers())
+
+    def test21_safe_base64_str_or_bytes_okay(self):
+        self.assertIsInstance(lib.safe_base64("test string"), str)
+        self.assertIsInstance(lib.safe_base64(b"test bytes"), str)
+
+    def test31_dns_challenge_okay(self):
+        res = lib.dns_challenge("a most spurious and unlikely key auth string")
+        self.assertEqual(res, "lNNwvD6ceN7n6Iugd3m3k6HQD8Wk6ytGvKkwhHAV_Hw")


### PR DESCRIPTION
Legacy DNS list changed to unordered (fix pypi display?)
Provider __init__ method interfaces revised - much is hoisted up to ProviderBase.
Added working example of legacy DNS driver that uses new aliasing!

PR for review - there will be at least some doc cleanups yet.  Oh, and **kwargs for legacy drivers, cli options...

LOTS of new or revised documentation and design notes in /docs, as well as some notes on a new or much modified sewer-cli, code name cloaca.

@menduo I think this finally addresses #154?

@SN9NV does this help with #123?

@aphexer this is as much as I can do for #175 from outside the individual drivers.  Want to modify one (and maybe make it the first migrated of our legacy drivers <wink>)?

@alanbacon I think this has overkilled #166, aside from needing to add **kwargs and cli option(s).

@komuw while playing around with the cloaca design, it occured to me that in that setting #114 might be a more interesting option.  You fix some, you re-energize some; bugs will be with us always.  :-/
