### PR TITLE
Add --acme_timout option to sewer-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ usage: sewer [-h] [--version] [--account_key ACCOUNT_KEY]
              [--bundle_name BUNDLE_NAME] [--endpoint {production,staging}]
              [--email EMAIL] --action {run,renew} [--out_dir OUT_DIR]
              [--loglevel {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
+             [--acme_timeout #seconds]
 
 Sewer is a Let's Encrypt(ACME) client.
 
@@ -247,6 +248,9 @@ optional arguments:
   --loglevel {DEBUG,INFO,WARNING,ERROR,CRITICAL}
                         The log level to output log messages at. eg:
                         --loglevel DEBUG
+  --acme_timeout SECONDS
+                        The maximum time the client will wait for a network call
+                        (HTTPS request to ACME server) to complete.  Default is 7
 ```
 
 The certificate, certificate key and account key will be saved in the directory

--- a/sewer/cli.py
+++ b/sewer/cli.py
@@ -148,6 +148,13 @@ def main():
         help="The log level to output log messages at. \
         eg: --loglevel DEBUG",
     )
+    parser.add_argument(
+        "--acme_timeout",
+        type=int,
+        required=False,
+        default=7,
+        help="The maximum time the client will wait for a network call (HTTPS request to ACME server) to complete.  Default is 7",
+    )
 
     args = parser.parse_args()
 
@@ -337,6 +344,7 @@ def main():
         certificate_key=certificate_key,
         ACME_DIRECTORY_URL=ACME_DIRECTORY_URL,
         LOG_LEVEL=loglevel,
+        ACME_REQUEST_TIMEOUT=args.acme_timeout,
     )
     certificate_key = client.certificate_key
     account_key = client.account_key


### PR DESCRIPTION
This is the enhancement @menduo presented in #154 lightly revised.  Biggest change is to the option name, which is --acme_timeout rather than just --timeout because there are already other timeouts that may need to be accessible through a sewer-cli option.