### PR TITLE
Fix failure to manage 2nd-level domains with Gandi

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -24,5 +24,6 @@ Contributors
 10. [@soloradish](https://github.com/soloradish)
 11. [Moritz Ulmer](https://www.protohaus.org)
 12. [rozgonik](https://github.com/rozgonik)
-13: [alec T](https://github.com/AlecTroemel)
-14: [Don S](https://github.com/donspaulding)
+13. [alec T](https://github.com/AlecTroemel)
+14. [Don S](https://github.com/donspaulding)
+15. [Julien Demoor](https://github.com/jdkx)

--- a/sewer/dns_providers/gandi.py
+++ b/sewer/dns_providers/gandi.py
@@ -125,4 +125,4 @@ class GandiDns(common.BaseDns):
 
     @staticmethod
     def subdomain_to_challenge_domain(subdomain):
-        return "_acme-challenge" + "." + subdomain
+        return "_acme-challenge" + (('.' + subdomain) if subdomain != '@' else '')

--- a/sewer/dns_providers/gandi.py
+++ b/sewer/dns_providers/gandi.py
@@ -51,7 +51,12 @@ class GandiDns(common.BaseDns):
             "rrset_type": "TXT",
             "rrset_ttl": self.RECORD_TTL,
             "rrset_name": GandiDns.subdomain_to_challenge_domain(subdomain),
-            "rrset_values": list(chain.from_iterable([subdomain_record['rrset_values'] for subdomain_record in subdomain_records])) + [domain_dns_value],
+            "rrset_values": list(
+                chain.from_iterable(
+                    [subdomain_record["rrset_values"] for subdomain_record in subdomain_records]
+                )
+            )
+            + [domain_dns_value],
         }
 
         if subdomain_records:
@@ -67,16 +72,16 @@ class GandiDns(common.BaseDns):
         self.delete_record(domain_name)
 
     def _get_subdomain_records(self, subdomain, all_records):
-        return list(
-            filter(lambda rec: rec["rrset_name"] == subdomain, all_records)
-        )
+        return list(filter(lambda rec: rec["rrset_name"] == subdomain, all_records))
 
     def delete_record(self, domain_name):
         [subdomain, base_domain] = GandiDns.split_domain(domain_name)
         zone_records_href = self.get_zone_records_href(base_domain)
         all_records = self.get_all_zone_records(zone_records_href)
 
-        subdomain_records = self._get_subdomain_records(GandiDns.subdomain_to_challenge_domain(subdomain), all_records)
+        subdomain_records = self._get_subdomain_records(
+            GandiDns.subdomain_to_challenge_domain(subdomain), all_records
+        )
         for subdomain_record in subdomain_records:
             del_record_resp = self.requests.delete(
                 subdomain_record["rrset_href"], headers=self.GET_HEADERS

--- a/sewer/dns_providers/gandi.py
+++ b/sewer/dns_providers/gandi.py
@@ -125,4 +125,4 @@ class GandiDns(common.BaseDns):
 
     @staticmethod
     def subdomain_to_challenge_domain(subdomain):
-        return "_acme-challenge" + (('.' + subdomain) if subdomain != '@' else '')
+        return "_acme-challenge" + (("." + subdomain) if subdomain != "@" else "")

--- a/sewer/dns_providers/tests/test_gandi.py
+++ b/sewer/dns_providers/tests/test_gandi.py
@@ -111,6 +111,11 @@ class TestGandiDns(TestCase):
         self.assertEqual(delete_calls[0][0][0], "mock_record_href")
 
     @mock_requests
+    def test_delete_non_existing_record(self, mock_requests_lib):
+        gandi_dns = GandiDns(GANDI_API_KEY=MOCK_GANDI_API_KEY, requests_lib=mock_requests_lib)
+        gandi_dns.delete_dns_record("no-exist.second-level-domain.tld", "val")
+
+    @mock_requests
     def test_create_record(self, mock_requests_lib):
         gandi_dns = GandiDns(GANDI_API_KEY=MOCK_GANDI_API_KEY, requests_lib=mock_requests_lib)
         gandi_dns.create_dns_record("subsubdomain.subdomain.second-level-domain.tld", "val")

--- a/sewer/dns_providers/tests/test_gandi.py
+++ b/sewer/dns_providers/tests/test_gandi.py
@@ -111,17 +111,6 @@ class TestGandiDns(TestCase):
         self.assertEqual(delete_calls[0][0][0], "mock_record_href")
 
     @mock_requests
-    def test_delete_non_existing_record(self, mock_requests_lib):
-        gandi_dns = GandiDns(GANDI_API_KEY=MOCK_GANDI_API_KEY, requests_lib=mock_requests_lib)
-        with self.assertRaises(RuntimeError) as context:
-            gandi_dns.delete_dns_record("no-exist.second-level-domain.tld", "val")
-
-        self.assertEqual(
-            "there is not exactly one record for domain: no-exist.second-level-domain.tld",
-            str(context.exception),
-        )
-
-    @mock_requests
     def test_create_record(self, mock_requests_lib):
         gandi_dns = GandiDns(GANDI_API_KEY=MOCK_GANDI_API_KEY, requests_lib=mock_requests_lib)
         gandi_dns.create_dns_record("subsubdomain.subdomain.second-level-domain.tld", "val")
@@ -149,7 +138,7 @@ class TestGandiDns(TestCase):
         self.assertEqual(
             post_calls[0][1]["json"]["rrset_name"], "_acme-challenge.subsubdomain.subdomain"
         )
-        self.assertEqual(post_calls[0][1]["json"]["rrset_values"], ["val"])
+        self.assertEqual(post_calls[0][1]["json"]["rrset_values"], ["challenge_text", "val"])
 
     @mock_requests
     def test_create_non_existing_record(self, mock_requests_lib):
@@ -170,9 +159,6 @@ class TestGandiDns(TestCase):
         self.assertEqual(get_calls[1][0][0], "mock_zone_records_href")
         self.assertEqual(len(delete_calls), 0)
 
-        self.assertEqual(
-            get_calls[2][0][0], "https://dns.api.gandi.net/api/v5/domains/second-level-domain.tld"
-        )
         self.assertEqual(post_calls[0][0][0], "mock_zone_records_href")
         self.assertEqual(post_calls[0][1]["json"]["rrset_type"], "TXT")
         self.assertEqual(post_calls[0][1]["json"]["rrset_ttl"], 10800)


### PR DESCRIPTION
## What

Changed the name used to create and remove TXT records with Gandi when authorizing 2nd-level domains.

## Why

Before this change, sewer failed to manage domains like "example.com" and its wildcard equivalent "*.example.com". Any such attempt would result in an HTTP error during creation of a TXT record. 

This was because sewer would attempt to create a TXT record under the name "_acme-challenge.@", whereas Gandi requires "_acme-challenge". 