### PR TITLE
Feature: Pass in a pre-configured route53 boto3 client to Route53Dns provider

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -27,3 +27,4 @@ Contributors
 13. [alec T](https://github.com/AlecTroemel)
 14. [Don S](https://github.com/donspaulding)
 15. [Julien Demoor](https://github.com/jdkx)
+15. [@tkalus](https://github.com/tkalus)

--- a/sewer/dns_providers/route53.py
+++ b/sewer/dns_providers/route53.py
@@ -16,11 +16,14 @@ class Route53Dns(common.BaseDns):
     connect_timeout = 30
     read_timeout = 30
 
-    def __init__(self, access_key_id=None, secret_access_key=None, **kwargs):
+    def __init__(self, access_key_id=None, secret_access_key=None, client=None, **kwargs):
         if not route53_dependencies:
             raise ImportError(
                 """You need to install Route53Dns dependencies. run; pip3 install sewer[route53]"""
             )
+
+        if (access_key_id or secret_access_key) and client:
+            raise RuntimeError("Pass keys OR preconfigured client, not both")
 
         self.aws_config = Config(
             connect_timeout=self.connect_timeout, read_timeout=self.read_timeout
@@ -33,6 +36,9 @@ class Route53Dns(common.BaseDns):
                 aws_secret_access_key=secret_access_key,
                 config=self.aws_config,
             )
+        elif client:
+            # Use the client passed in from the caller.
+            self.r53 = client
         else:
             # let boto3 find credential
             # https://boto3.readthedocs.io/en/latest/guide/configuration.html#best-practices-for-configuring-credentials

--- a/sewer/dns_providers/tests/test_route53.py
+++ b/sewer/dns_providers/tests/test_route53.py
@@ -78,6 +78,18 @@ class TestRoute53(TestCase):
         )
 
     @mock.patch("sewer.dns_providers.route53.boto3.client")
+    def test_user_given_client(self, mock_client):
+        passed_client = mock.MagicMock()
+        dns_class = Route53Dns(client=passed_client)
+        mock_client.assert_not_called()
+        self.assertEqual(passed_client, dns_class.r53)
+
+    @mock.patch("sewer.dns_providers.route53.boto3.client")
+    def test_user_given_creds_and_client(self, mock_client):
+        with self.assertRaises(RuntimeError):
+            Route53Dns(access_key_id="mock-key", client=mock.MagicMock())
+
+    @mock.patch("sewer.dns_providers.route53.boto3.client")
     def test_user_not_given_credential(self, mock_client):
         dns_class = Route53Dns()
         mock_client.assert_called_once_with("route53", config=dns_class.aws_config)


### PR DESCRIPTION
 ## What(What have you changed?)
Allowing the caller to pass in a pre-configured route53 boto3 client on the Route53Dns provider

## Why(Why did you change it?)
Covers use-cases where the caller:
- has STS credentials
- where a AssumeRole is necessary (E.G. Hosted Zone in a different AWS Account).

Closes #197 