### PR TITLE
Documentation; JSON catalogs; library support

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ Features and Improvements:
 - added `--p_opt <name>=<value>` for passing kwargs to drivers
 - Added optional parameters accepted by base class for DNS drivers:
   - `alias=<alias_domain>` specifies a separate domain for DNS challenges
+    (requires driver support, see [Aliasing](Aliasing))
   - `prop_delay=<seconds>` gives a fixed delay (sleep) after challenge setup
 - gandi (legacy DNS driver) fixed internal bugs that broke common wildcard
   use cases (eg., `*.domain.tld`) as well as the "wildcard plus" pattern
@@ -21,6 +22,12 @@ Features and Improvements:
   could be useful to someone, maybe.
 
 Internals:
+- added [catalog.py](catalog) to manage provider catalogs; includes
+  get_provider(name) method to replace `import ......{name.}ClassName`
+- replace __version__.py with sewer.json; setup.py converted; add sewer_about()
+  in lib.py; cli.py converted; client.py converted
+- added catalog.json defining known drivers and their interfaces; also
+  information about dependencies for setup.py
 - added `**kwargs` to all legacy providers to allow new options that are
   handled in a parent class to pass through (for `alias`, `prop_delay`, etc.)
 - removed imports that were in `sewer/__init__` and
@@ -30,6 +37,8 @@ Internals:
 - added `__main__.py` to support `python3 -m sewer` invocation of sewer-cli
 - fixed imports in client.py that didn't actually import the parts of
   OpenSSL and cryptography that we use (worked because we import requests?)
+
+See also [release notes](notes/0.8.3-notes).
 
 ## **version:** 0.8.2
 Feature additions:

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -1,0 +1,142 @@
+## Driver Catalog
+
+The driver catalog, `sewer/catalog.json`, replaces scattered facilities that
+were used to stitch things together.  The import farms in `sewer.__init__`
+and `sewer.dns_providers.__init__` have already been removed; with the
+catalog in place, redundant lists in cli.py and setup.py are also removed,
+replaced by use of the catalog's data and a few lines of code.  The
+`dns_provider_name` is deprecated in favor of the catalog as well.
+
+`catalog.py` wraps the catalog in a class, adding some convenience methods
+for listing the known drivers, looking up a driver's data by name, and
+loading a driver's implementation class by name.  But using the catalog
+without `catalog.py` is as easy as loading it using the standard lib's json
+facilities - it's all lists & dicts (see eg. setup.py which loads the
+catalog this way to avoid potential issues with trying to call into the
+package's code before it's installed).
+
+### Catalog structure
+
+The catalog resides in a JSON file that loads as an array of dictionaries,
+one element for each registered driver.  The per-driver record contains the
+following items (some optional):
+
+- **name** The name used to identify this driver, eg., `--provider <name>`
+  to `sewer-cli`.  These names need to be unique, but are not required to
+  match the module or implementing class names.  (legacy DNS drivers usually
+  matched the module name, but not always)
+- **desc** A brief description of the driver, intended for display to humans
+  to help them understand what each driver is, eg. in --known_providers output
+- **chals** list of strings for the type of challenge(s) this driver
+  handles.  (if more than one type, in order of preference?)
+- **args** A list of the driver-specific [parameters](#args-parameter-descriptors)
+- **path** The path to use to import the driver's Python module.
+  _Default_ is `sewer.providers.{name}`
+- **cls** Name of module attribute which is called with parameters to get a
+  working instance of the driver.  Usually a class, but a factory function
+  may be used.  _Default_ is `Provider`.
+- **features** - a list of strings that name the optional features that this
+  driver supports.  _Default_ is an empty list.
+- **memo** Additional text/comments about the driver, the descriptor, etc.
+- **deps** list of additional projects this driver requires (for setup)
+
+### args - parameter desciptors
+
+This is a bit of a mess due to legacy drivers that ignored the established
+conventions.  To be fair to them, those conventions weren't clearly
+documented (then - see below).  This adds some complications to preserve
+compatibility, as usual.  Let's begin with a minimal descriptor for a driver
+that conforms to the new convention (hint: it's imaginary at this time):
+
+    {
+      "name": "well_behaved",
+      "desc": "made-up example driver that's mostly defaults",
+      "chals": ["dns-01"],
+      "args": [
+        { "name": "api_id", "req": 1 },
+        { "name": "api_key", "req": 1},
+      ],
+      "features": [ "alias" ],
+    }
+
+This describes a dns-01 challenge driver that is found in the module
+`sewer.providers.well_behaved`, constructed from a class named `Provider`.
+The constructor takes two required arguments, `api_id` and `api_key`, which
+the program should accept from environment variables `WELL_BEHAVED_API_ID"
+and "WELL_BEHAVED_API_KEY".  Since it is a `dns-01` challenge provider and
+up to date, it adds the claim that it supports the `alias` feature.  It
+doesn't support the "unpropagated" feature - perhaps the DNS service has no
+API to check the propagation of changes.
+
+If this had been a difficult old legacy driver, the descriptor might have
+looked more like this:
+
+    {
+      "name": "difficult",
+      "desc": "made-up example driver that's as non-default as can be",
+      "chals": ["dns-01"],
+      "args": [
+        { "name": "api_id",
+          "req": 1,
+          "param": "difficult_api_id",
+          "envvar": "DIFFICULT_DNS_API_ID",
+        },
+        { "name": "api_key",
+          "req": 1,
+          "param": "DIFFICULT_API_KEY",
+          "envvar": "DIFFICULT_DNS_API_KEY"},
+        },
+	{ "name": "api_base_url",
+	  "param": "API_BASE_URL",
+	  "envvar": "",
+	},
+      ],
+      "path": "sewer.dns_providers.difficultdns",
+      "cls": "DifficultDNSDns",
+      "features": [],
+      "memo", "difficult, indeed..."
+    }
+
+This driver has both parameter names and envvar names that defy convention,
+so both the parameter and envvar name must be given explicitly.  There is
+also an optional parameter that has never had an associated envvar that the
+implementation used.
+
+### driver parameter and environment variable names
+
+The convention is that the envvar name (if any) SHOULD be formed from the
+driver name and the individual args' names (see the first envvar rule
+below).  This gives envvar names similar to, sometimes identical to, the
+ones already used with legacy DNS drivers.  One thing that is changing is
+that the parameter names, which in the old convention were
+THE_SAME_AS_ENVVAR_NAMES, are changing to be lower case and losing
+driver-name prefixes, etc.  Where appropriate, the new names will use just a
+few shared names, viz., `id`, `key`, `token`.
+
+Obviously the drivers and envvar names are not so consistent among the
+legacy DNS drivers.  Therefore the descriptor has both `param` and `envvar`
+values, along with a set of rules for resolving the names to be used.
+
+#### parameter name rules
+
+1. `descriptor.args[n].name` is the "modern" name for the nth parameter
+2. if `param` is given, it overrides the "modern" name
+
+#### environment name rules
+
+1. f"{descriptor.name}_{descriptor.args[n].name}".upper() is the default
+2. if `envvar` is given, it overrides the default
+
+Two guidelines for the use of envvars:
+
+1. If `envvar` is given, is not the empty string, and the so-named envvar is
+   not found, the invoking code MAY also look for the default-named envvar
+   before reporting a missing envvar.
+
+2. If `envvar` is set to the empty string, then catalog using code will not
+   look for a matching envvar at all.
+
+### catalog representation in Python
+
+For now, see the brief implementation in sewer/catalog.py for the way the
+JSON structure is mapped into a ProviderDescriptor instance.

--- a/docs/dns-01.md
+++ b/docs/dns-01.md
@@ -19,6 +19,7 @@ service's API is difficult.
 - [Hurricane Electric DNS](https://dns.he.net/)
 - [PowerDNS](https://doc.powerdns.com/authoritative/http-api/index.html)
 - [Rackspace](https://www.rackspace.com/cloud/dns)
+- [unbound_ssh]
 
 ### Add a driver for your DNS service
 
@@ -95,8 +96,11 @@ Three features that have varying support in the Legacy drivers.
 | hurricane | ? | no | no | test coverage 70% |
 | powerdns | NO | no | no | apparently not in 0.8.2; bug #195 |
 | rackspace | ? | no | no | test coverage 69% | 
-| route53 | OK | no | no | wildcard since pre-0.8.2 |
+| route53 (1) | OK | no | no | wildcard since pre-0.8.2 |
 | unbound_ssh | OK | yes | no | Working demonstrator model |
+
+> (1) route53 was never setup to be used from `sewer-cli`.  That will change,
+maybe for 0.8.3, but does anyone care?  No complaints have been heard...
 
 _wildcard_ is NOT the older issue - since 0.8.2, all drivers should be able
 to support creating certificates for simple `*.domain.tld` requests.

--- a/docs/drivers/route53.md
+++ b/docs/drivers/route53.md
@@ -1,0 +1,17 @@
+## route53 - driver for AWS DNS service
+
+### Command line use
+
+route53 has never been wired into `sewer-cli`, and that hasn't really
+changed in 0.8.3.  It does appear in the list of "known providers", but it
+isn't usable, and raises an exception if named by `--provider`.
+
+Adding that integration is on the list, but seeing as no one has complained
+about this lack up to now it's nowhere near the top.  :-(
+
+### Programmatic use
+
+Apparently everyone using sewer's route53 has been rolling their own
+wrapper, since it has only been available for such use to date.  There is a
+patch to extend that Route53Dns.__init__ to allow additional AWS-specific
+methods of authentication which I expect will ship in 0.8.3.

--- a/docs/drivers/unbound_ssh.md
+++ b/docs/drivers/unbound_ssh.md
@@ -1,17 +1,21 @@
 ## unbound_ssh legacy DNS driver
 
-A working, if somewhat quirky, driver to setup challenges in the unbound
-server, using ssh to connect to an account able to run unbound-control
-commands.  The driver does NOT handle the login authorization, assuming that
-it is running interactively and ssh will prompt for your input, or that a
-key agent (eg., ssh-agent) is active to supply the cryptographic
-credentials.
+A working, if somewhat quirky, driver to setup challenges in local data of
+the [unbound](https://nlnetlabs.nl/projects/unbound/about/) caching
+resolver.  As the name suggests, it relies upon ssh to provide an
+authenticated connection the server; inside that connection the
+`unbound-control` program is used to add and remove the records.  The driver
+does NOT handle the login authorization, assuming that it is running
+interactively and ssh will prompt for your input, or that a key agent (eg.,
+ssh-agent) is active to supply the cryptographic credentials.  That's the
+_somewhat quirky_ part!
 
 ### `__init__(self, *, ssh_des, **kwargs)`
 
 There is one REQUIRED parameter, `ssh_des`, which is the login target, such
 as acme_user@ns1.example.com.  This is simply passed to the ssh command,
-with the unbound-control commands passed as the command to execute remotely.
+along with the `unbound-control` commands to be executed on the destination
+machine.
 
 ### Driver features
 
@@ -38,3 +42,7 @@ Sadly, This was written using the old paradigm where both the module name
 and the class name were more-or-less the same name aside from
 capitalization... and often less predictable changes.  Should have been
 unbound_ssh.Provider ...
+
+The `unbound-control` commands generated could be run locally with not very
+much change to the driver.  Perhaps that will become part of a demonstration
+of some different features in the future.

--- a/docs/notes/0.8.3-notes.md
+++ b/docs/notes/0.8.3-notes.md
@@ -1,4 +1,4 @@
-# Sewer 0.8.3 Release Notes
+## Sewer 0.8.3 Release Notes
 
 This will attempt to list all the changes that affect users of the
 `sewer-cli` program, including even cosmetic changes.  If you use sewer as a
@@ -7,7 +7,7 @@ library you may find internal changes not called out here.
 **New `sewer-cli` features are usually just mentioned, see
 [sewer-cli.md](sewer-cli) for more complete documentation.**
 
-## What's New
+### What's New
 
 - added many words in the /docs directory.  A lot of it is internals
   documentation; a lot of it was written to help me understand exactly how
@@ -34,7 +34,7 @@ library you may find internal changes not called out here.
 **NB: `--alias_domain` and the planned `--prop_*` options were only added
 during PRE-0.8.3, so they will just be dropped in the release.**
 
-## What's Changed
+### What's Changed
 
 Mostly I've tried to avoid changes that were likely to break things.  More
 so for `sewer-cli` than those who use the inner workings of Client, of
@@ -59,10 +59,34 @@ course.
   a legacy DNS driver.  Needs a rather specific environment to work, but I
   just renewed a handful of certificates using it the other day.
 
-## Breakage
+- JSON configuration has arrived.  sewer.json replaces __version__.py.
+  catalog.json adds a central description of known drivers, replacing the
+  mess of imports [removed], some non-DRY lists in setup.py and cli.py.
+
+- `sewer.catalog` provides loading of the JSON catalog as well as methods to
+  lookup the descriptor and load the module; replaces the mess of imports
+
+### Breakage
 
 - removed all the imports in __init__.py (both sewer & dns_providers).  This
   *will* affect you if you've just done `import sewer` and access especially
-  the provider classes as eg.  `sewer.ThatDNSDns`.  Using proper imports,
+  the provider classes as eg.  `sewer.ThatDNSDns`.  ~~Using proper imports,
   eg., `import sewer.dns_providers.thatdns.ThatDNSDns` is the current
-  workaround, sorry.  **This does NOT affect `sewer-cli` users.**
+  workaround, sorry.~~  Recommended use is now something like
+  ```
+  from sewer import catalog
+
+  pro_cls = catalog.ProviderCatalog().get_provider("route53")
+  provider = pro_cls(...arguments as needed...)
+
+  # use of route53 is ironic: it has no catalog entry because it has
+  # never been integrated into `sewer-cli`, which was what drove the
+  # creation of the catalog  [right, another FIX ME]
+  ```
+  **This does NOT affect `sewer-cli` users.**
+
+### Deprecated
+
+- `--action {run,renew}` option has never actually had any effect and is no
+  longer required (since 0.8.2?).  LOGS A WARNING IN 0.8.3.
+- ...

--- a/sewer/__version__.py
+++ b/sewer/__version__.py
@@ -1,7 +1,0 @@
-__title__ = "sewer"
-__description__ = "Sewer is a programmatic Lets Encrypt(ACME) client"
-__url__ = "https://github.com/komuw/sewer"
-__version__ = "PRE-0.8.3"
-__author__ = "komuW"
-__author_email__ = "komuw05@gmail.com"
-__license__ = "MIT"

--- a/sewer/catalog.json
+++ b/sewer/catalog.json
@@ -1,0 +1,202 @@
+[
+  { "name": "acmedns",
+    "desc": "AcmeDns DNS provider",
+    "chals": ["dns-01"],
+    "args": [
+      { "name": "api_user",
+        "req": 1,
+        "old_param": "ACME_DNS_API_USER"
+      },
+      { "name": "api_key",
+        "req": 1,
+        "old_param": "ACME_DNS_API_KEY"
+      },
+      { "name": "api_base_url",
+        "req": 1,
+        "old_param": "ACME_DNS_API_BASE_URL"
+      }
+    ],
+    "path": "sewer.dns_providers.acmedns",
+    "cls": "AcmeDnsDns",
+    "deps": ["dnspython"]
+    },
+  { "name": "aliyun",
+    "desc": "Alibaba Cloud DNS service",
+    "chals": ["dns-01"],
+    "args": [
+      { "name": "ak",
+        "req": 1,
+        "old_param": "aliyun_ak",
+        "old_envvar": "ALIYUN_AK_ID"
+      },
+      { "name": "secret",
+        "req": 1,
+        "old_param": "aliyun_secret",
+        "old_envvar": "ALIYUN_AK_SECRET"
+      },
+      { "name": "endpoint",
+        "old_param": "aliyun_endpoint",
+        "old_envvar": "ALIYUN_ENDPOINT"
+      }
+    ],
+    "path": "sewer.dns_providers.aliyundns",
+    "cls": "AliyunDns",
+    "deps": ["aliyun-python-sdk-core-v3", "aliyun-python-sdk-alidns"],
+    "memo": "default value of endpoint in ad-hoc cli.py code - add default to args?"
+  },
+  { "name": "aurora",
+    "desc": "Aurora DNS service from pcextreme hosting",
+    "chals": ["dns-01"],
+    "args": [
+      { "name": "api_key",
+        "req": 1
+      },
+      { "name": "secret_key",
+        "req": 1
+      }
+    ],
+    "path": "sewer.dns_providers.auroradns",
+    "cls": "AuroraDns",
+    "deps": ["tldextract", "apache-libcloud"]
+    },
+  { "name": "cloudflare",
+    "desc": "Cloudflare DNS using either email & key or just a token",
+    "chals": ["dns-01"],
+    "args": [
+      { "name": "email"},
+      { "name": "api_key"},
+      { "name": "api_base_url"},
+      { "name": "token"}
+    ],
+    "path": "sewer.dns_providers.cloudflare",
+    "cls": "CloudFlareDns",
+    "deps": [],
+    "memo": "accepts EITHER token OR both email & key; drive MUST sanity check"
+    },
+  { "name": "cloudns",
+    "desc": "ClouDNS service",
+    "chals": ["dns-01"],
+    "args": [
+    ],
+    "path": "sewer.dns_providers.cloudns",
+    "cls": "ClouDNSDns",
+    "deps": ["cloudns-api"],
+    "memo": "API library grovels the environment for its access parameters directly"
+  },
+  { "name": "dnspod",
+    "desc": "DNSPod DNS provider",
+    "chals": ["dns-01"],
+    "args": [
+      { "name": "id", "req": 1},
+      { "name": "api_key", "req": 1},
+      { "name": "api_base_url"}
+    ],
+    "path": "sewer.dns_providers.dnspod",
+    "cls": "DNSPodDns",
+    "deps": [],
+    "memo": "api_base_url not usually used?  [VERIFY]"
+    },
+  { "name": "duckdns",
+    "desc": "DuckDNS DNS provider",
+    "chals": ["dns-01"],
+    "args": [
+      { "name": "token",
+        "req": 1,
+        "old_param": "duckdns_token",
+        "old_envvar": "DUCKDNS_TOKEN"
+      },
+      { "name": "api_base_url",
+        "old_param": "DUCKDNS_API_BASE_URL",
+        "old_envvar": ""
+      }
+    ],
+    "path": "sewer.dns_providers.duckdns",
+    "cls": "DuckDNSDns",
+    "deps": [],
+    "memo": "as-is code does not look for envvar for base_url; maybe for testing only?"
+    },
+  { "name": "gandi",
+    "desc": "Gandi DNS service",
+    "chals": ["dns-01"],
+    "args": [
+      { "name": "api_key",
+        "req": 1,
+        "old_param": "GANDI_API_KEY"
+      }
+    ],
+    "path": "sewer.dns_providers.gandi",
+    "cls": "GandiDns",
+    "deps": []
+  },
+  { "name": "hurricane",
+    "desc": "Hurricane Electric DNS service",
+    "chals": ["dns-01"],
+    "args": [
+      { "name": "username",
+        "req": 1,
+        "old_param": "he_username"
+      },
+      { "name": "password",
+        "req": 1,
+        "old_param": "he_password"
+      }
+    ],
+    "path": "sewer.dns_providers.hurricane",
+    "cls": "HurricaneDns",
+    "deps": ["hurricanedns"]
+  },
+  { "name": "powerdns",
+    "desc": "PowerDNS DNS provider",
+    "chals": ["dns-01"],
+    "args": [
+      { "name": "api_key",
+        "req": 1,
+        "old_param": "powerdns_api_key",
+        "old_envvar": "POWERDNS_API_KEY"
+      },
+      { "name": "api_url",
+        "req": 1,
+        "old_param": "powerdns_api_url",
+        "old_envvar": "POWERDNS_API_URL"
+      }
+    ],
+    "path": "sewer.dns_providers.powerdns",
+    "cls": "PowerDNSDns",
+    "deps": [],
+    "memo": "could drop old_envvar if prediction ignored old_param?"
+    },
+  { "name": "rackspace",
+    "desc": "Rackspace DNS service",
+    "chals": ["dns-01"],
+    "args": [
+      { "name": "username", "req": 1},
+      { "name": "api_key", "req": 1}
+    ],
+    "path": "sewer.dns_providers.rackspace",
+    "cls": "RackspaceDns",
+    "deps": ["tldextract"]
+    },
+  { "name": "route53",
+    "desc": "Amazon cloud DNS service",
+    "chals": ["dns-01"],
+    "args": [
+      { "name": "id", "req": 1, "old_param": "access_key_id"},
+      { "name": "key", "req": 1, "old_param": "secret_access_key"}
+    ],
+    "path": "sewer.dns_providers.route53",
+    "cls": "Route53Dns",
+    "deps": ["boto3"],
+    "memo": "DUMMY LISTING: route53 has never been integrated into cli.py, so this DOESN'T WORK yet"
+  },
+  { "name": "unbound_ssh",
+    "desc": "Working demonstrater of legacy DNS adopting new features",
+    "chals": ["dns-01"],
+    "args": [
+      { "name": "ssh_des", "req": 1, "envvar": "" }
+    ],
+    "path": "sewer.dns_providers.unbound_ssh",
+    "cls": "UnboundSsh",
+    "features": ["alias"],
+    "deps": []
+  }  
+]

--- a/sewer/catalog.py
+++ b/sewer/catalog.py
@@ -1,0 +1,78 @@
+import codecs, importlib, json, os, sys
+from typing import Dict, List, Sequence
+
+from .auth import ProviderBase
+
+
+class ProviderDescriptor:
+    def __init__(
+        self,
+        *,
+        name: str,
+        desc: str,
+        chals: Sequence[str],
+        args: Sequence[Dict[str, str]],
+        deps: Sequence[str],
+        path: str = None,
+        cls: str = None,
+        features: Sequence[str] = None,
+        memo: str = None
+    ) -> None:
+        "initialize a driver descriptor from one item in the catalog"
+
+        self.name = name
+        self.desc = desc
+        self.chals = chals
+        self.args = args
+        self.deps = deps
+        self.path = path
+        self.cls = cls
+        self.features = [] if features is None else features
+        self.memo = memo
+
+    def __str__(self) -> str:
+        return "Descriptor %s" % self.name
+
+    def get_provider(self) -> ProviderBase:
+        "return the class that implements this driver"
+
+        module_name = self.path if self.path else ("sewer.providers." + self.name)
+        module = importlib.import_module(module_name)
+        return getattr(module, self.cls if self.cls else "Provider")
+
+
+class ProviderCatalog:
+    def __init__(self, filepath: str = "") -> None:
+        "intialize a catalog from either the default catalog.json or one named by filepath"
+
+        if not filepath:
+            here = os.path.abspath(os.path.dirname(__file__))
+            filepath = os.path.join(here, "catalog.json")
+        with codecs.open(filepath, "r", encoding="utf8") as f:
+            raw_catalog = json.load(f)
+
+        items: Dict[str, ProviderDescriptor] = {}
+        for item in raw_catalog:
+            k = item["name"]
+            if k in items:
+                print("WARNING: duplicate name %s skipped in catalog %s" % (k, filepath))
+            else:
+                items[k] = ProviderDescriptor(**item)
+        self.items = items
+
+    def get_item_list(self) -> List[ProviderDescriptor]:
+        "return the list of items in the catalog, sorted by name"
+
+        res = [i for i in self.items.values()]
+        res.sort(key=lambda i: i.name)
+        return res
+
+    def get_descriptor(self, name: str) -> ProviderDescriptor:
+        "return the ProviderDescriptor that matches name"
+
+        return self.items[name]
+
+    def get_provider(self, name: str) -> ProviderBase:
+        "return the class that implements the named driver"
+
+        return self.get_descriptor(name).get_provider()

--- a/sewer/dns_providers/tests/test_unbound_ssh.py
+++ b/sewer/dns_providers/tests/test_unbound_ssh.py
@@ -1,0 +1,75 @@
+import logging
+import unittest
+from unittest import mock, TestCase
+
+
+from .. import unbound_ssh
+
+
+####### Mocks and other helpers #######
+
+
+class response:
+    "web request body content and or JSON nominally decoded from body"
+
+    def __init__(self, *, content_val="", json_val=None):
+        self.content = content_val
+        self._json = json_val
+
+    def json(self):
+        if self._json is None:
+            raise ValueError("No json here")
+        return self._json
+
+
+class MockObj:
+    def __init__(self, **kwargs) -> None:
+        self.__dict__.update(kwargs)
+
+
+def patch_subprocess_run(returncode, **kwargs):
+    return mock.patch("subprocess.run", return_value=MockObj(returncode=returncode, **kwargs))
+
+
+####### TESTS #######
+
+
+class TestLib(unittest.TestCase):
+
+    # __init__ requires & accepts args, fails on missing
+
+    def test01_init_requires_ssh_des(self):
+        with self.assertRaises(TypeError):
+            unbound_ssh.UnboundSsh()  # pylint: disable=E1125
+
+    def test02_init_okay(self):
+        self.assertTrue(unbound_ssh.UnboundSsh(ssh_des="nobody@nowhere.man"))
+
+    def test03_init_with_alias_okay(self):
+        self.assertTrue(unbound_ssh.UnboundSsh(ssh_des="nobody@nowhere.man", alias="example.com"))
+
+    # local function unbound_command rejects invalid command
+
+    def test13_unbound_command_bad_cmd_fails(self):
+        with self.assertRaises(ValueError):
+            unbound_ssh.unbound_command("bad", "fqdn", "acme_challenge")
+
+    # end to end tests (up to calling out to ssh, of course)
+
+    def test21_create_delete_dns_record_okay(self):
+        "test create and delete with the ssh callout mocked"
+
+        provider = unbound_ssh.UnboundSsh(ssh_des="nobody@nowhere.man")
+        with patch_subprocess_run(0) as sub_run_mock:
+            provider.create_dns_record("example.com", "a1b2c3d4e5f6g7h8i9j0")
+            provider.delete_dns_record("example.com", "a1b2c3d4e5f6g7h8i9j0")
+            self.assertTrue(sub_run_mock.call_count == 2)
+
+    def test22_create_dns_record_fail(self):
+        "only runs through create since the fail point is in the method both call"
+
+        provider = unbound_ssh.UnboundSsh(ssh_des="nobody@nowhere.man")
+        with patch_subprocess_run(42, args=None) as sub_run_mock:
+            with self.assertRaises(RuntimeError):
+                provider.create_dns_record("example.com", "a1b2c3d4e5f6g7h8i9j0")
+            self.assertTrue(sub_run_mock.call_count == 1)

--- a/sewer/lib.py
+++ b/sewer/lib.py
@@ -1,11 +1,11 @@
-import base64, logging
+import base64, codecs, json, logging, os
 from hashlib import sha256
 from typing import Any, Union
 
 LoggerType = logging.Logger
 
 
-### FIX ME ### can be more specific about response's type... somehow
+### FIX ME ### can be more specific about response arg's type... somehow
 
 
 def log_response(response: Any) -> str:
@@ -47,3 +47,20 @@ def dns_challenge(key_auth: str) -> str:
     "return the ACME challenge response for a DNS TXT record"
 
     return safe_base64(sha256(key_auth.encode("utf8")).digest())
+
+
+_sewer_about = None
+
+
+def sewer_about(name: str) -> str:
+    """
+    returns the named attribute from lazily-loaded  sewer.json (replaces __version__.py)
+    """
+
+    global _sewer_about
+
+    if _sewer_about is None:
+        here = os.path.abspath(os.path.dirname(__file__))
+        with codecs.open(os.path.join(here, "sewer.json"), "r", encoding="utf8") as f:
+            _sewer_about = json.load(f)
+    return _sewer_about[name]

--- a/sewer/sewer.json
+++ b/sewer/sewer.json
@@ -1,0 +1,9 @@
+{
+  "title": "sewer",
+  "description": "Sewer is a programmatic Lets Encrypt(ACME) client",
+  "url": "https://github.com/komuw/sewer",
+  "version": "0.8.3-beta",
+  "author": "komuW",
+  "author_email": "komuw05@gmail.com",
+  "license": "MIT"
+}

--- a/sewer/tests/test_catalog.py
+++ b/sewer/tests/test_catalog.py
@@ -1,0 +1,26 @@
+import logging
+import unittest
+
+from .. import auth, catalog
+
+
+class TestLib(unittest.TestCase):
+    def test01_ProviderCatalog_create(self):
+        cat = catalog.ProviderCatalog()
+        self.assertIsInstance(cat, catalog.ProviderCatalog)
+
+    def test02_catalog_get_item_list_okay(self):
+        cat = catalog.ProviderCatalog()
+        self.assertIsInstance(cat.get_item_list(), list)
+
+    def test03_catalog_get_descriptor_okay(self):
+        cat = catalog.ProviderCatalog()
+        self.assertIsInstance(cat.get_descriptor("unbound_ssh"), catalog.ProviderDescriptor)
+
+    def test04_catalog_get_provider_okay(self):
+        cat = catalog.ProviderCatalog()
+        provider = cat.get_provider("unbound_ssh")(ssh_des="noone@nowhere")
+        self.assertIsInstance(provider, auth.ProviderBase)
+
+    def test_05_catalog__str__okay(self):
+        self.assertTrue(str(catalog.ProviderCatalog()))

--- a/sewer/tests/test_lib.py
+++ b/sewer/tests/test_lib.py
@@ -35,3 +35,7 @@ class TestLib(unittest.TestCase):
     def test31_dns_challenge_okay(self):
         res = lib.dns_challenge("a most spurious and unlikely key auth string")
         self.assertEqual(res, "lNNwvD6ceN7n6Iugd3m3k6HQD8Wk6ytGvKkwhHAV_Hw")
+
+    def test41_sewer_about_okay(self):
+        res = lib.sewer_about("license")
+        self.assertEqual(res, "MIT")


### PR DESCRIPTION
Add catalog.json, replacing ad-hoc lists of providers in cli.py & setup.py.
catalog.py for easy use of the catalog, including loading known providers.
Add sewer.json info replaces `__version__.py`; sewer_about in lib to access it.
