### PR TITLE
handle case where provider challenge types not in response

### DIFF
--- a/sewer/client.py
+++ b/sewer/client.py
@@ -420,6 +420,13 @@ class Client:
                     "challenge_url": challenge_url,
                 }
 
+        if not identifier_auth:
+            raise ValueError(
+                "Error getting authorization: provider challenge types {} not in response".format(
+                    self.provider.chal_types
+                )
+            )
+
         self.logger.debug(
             "get_identifier_authorization_success. identifier_auth={0}".format(identifier_auth)
         )


### PR DESCRIPTION
## What
Handle case where identifier authorization response does not include challenge type in the providers `chal_types` 

## Why
The challenges list returned in the identifier auth response may not include the challenge type of the provider the client is set up with. Here's the relevant part of the RFC

[RFC 8555 Section 7.1.4 19](https://tools.ietf.org/html/rfc8555#section-7.1.4):

>    For pending authorizations, the challenges that the client can fulfill in order to prove possession of the identifier. For valid authorizations, the challenge that was validated. For invalid authorizations, the challenge that was attempted and failed.

For example, if I am trying to acquire a cert for a domain using DNS validation, but there is already a valid cert that used HTTP validation, lets-encrypt will not include the DNS block in the response. Currently that will result in this (possibly confusing) error.

```
raised unexpected: UnboundLocalError("local variable 'identifier_auth' referenced before assignment")
```

this PR attempts to catch this situation and throw a more relevant error

