### PR TITLE
Revert "Update sewer-cli.md"

### DIFF
--- a/docs/sewer-cli.md
+++ b/docs/sewer-cli.md
@@ -165,7 +165,7 @@ used up.  Default is "1,2,4,8".  _to be added when there's driver support_
 
 `--p_opts alias_domain=<alias_domain_name>`
 > Configure an alternate DNS domain in which the challenge responses will be
-placed.  See [docs/Aliasing.md](Aliasing.md) for details.  **Legacy DNS
+placed.  See [docs/Aliasing.md](Aliasing) for details.  **Legacy DNS
 providers accept this, but require further modification to actually apply
 the aliasing that's supported by their parent classes.**
 _This was `--alias_domain <name>` during 0.8.3 development.`

--- a/docs/sewer-cli.md
+++ b/docs/sewer-cli.md
@@ -165,7 +165,7 @@ used up.  Default is "1,2,4,8".  _to be added when there's driver support_
 
 `--p_opts alias_domain=<alias_domain_name>`
 > Configure an alternate DNS domain in which the challenge responses will be
-placed.  See [docs/Aliasing.md](Aliasing) for details.  **Legacy DNS
+placed.  See [Aliasing](docs/Aliasing) for details.  **Legacy DNS
 providers accept this, but require further modification to actually apply
 the aliasing that's supported by their parent classes.**
 _This was `--alias_domain <name>` during 0.8.3 development.`


### PR DESCRIPTION
Reverts komuw/sewer#217

I had to scratch my head to figure this one out.  It's rooted in the half-assed "pages" feature github has, and ought to have been `[Aliasing](docs/Aliasing)`, as most of the core docs have been migrated to the web pages view.   Which I still think is better than having wiki pages that aren't versioned in the repo, but it still leaves a lot to be desired.