### PR TITLE
Fix errant quote in examples causing highlighting failure

### DIFF
--- a/docs/sewer-as-a-library.md
+++ b/docs/sewer-as-a-library.md
@@ -86,7 +86,7 @@ print("your letsencrypt.org account key is:", acct_key.private_bytes())
 # NB: your certificate_key and account_key should be SECRET.
 # You can write these out to individual files, eg::
 
-with open("certificate.crt", "wb"') as f:
+with open('certificate.crt', 'wb') as f:
     f.write(certificate.private_bytes())
 with open('certificate.key', 'wb') as f:
     f.write(certkey.private_bytes())


### PR DESCRIPTION
Thank you for contributing to sewer.                    
Every contribution to sewer is important to us.                       
You may not know it, but you have just contributed to making the world a more safer and secure place.                         

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to sewer, and sewer agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that sewer shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Picture of the problem:
![image](https://user-images.githubusercontent.com/1041838/107270414-c35a8b00-69ff-11eb-813e-ab75a4edbc22.png)


Now,                   

## What(What have you changed?)
- Fix errant quote in examples causing highlighting failure

## Why(Why did you change it?)
- I want syntax highlighting on the example page to work
