### PR TITLE
Client initialization, termsOfService key should be optional

### DIFF
--- a/sewer/client.py
+++ b/sewer/client.py
@@ -94,7 +94,10 @@ class Client:
             self.User_Agent = self.get_user_agent()
             acme_endpoints = self.get_acme_endpoints().json()
             self.ACME_GET_NONCE_URL = acme_endpoints["newNonce"]
-            self.ACME_TOS_URL = acme_endpoints["meta"]["termsOfService"]
+            try:
+                self.ACME_TOS_URL = acme_endpoints["meta"]["termsOfService"]
+            except KeyError:
+                self.ACME_TOS_URL = None
             self.ACME_KEY_CHANGE_URL = acme_endpoints["keyChange"]
             self.ACME_NEW_ACCOUNT_URL = acme_endpoints["newAccount"]
             self.ACME_NEW_ORDER_URL = acme_endpoints["newOrder"]


### PR DESCRIPTION
Hi,

During the client initialization, sewer expect that the `termsOfService` url is present in the `meta` of the endpoints.

However, `termsOfService` is optional (actually, the `meta` key itself is optional, see page 23 of [RFC 8555](https://www.rfc-editor.org/rfc/rfc8555.html#section-7.1.1)) and while it works on most public servers, the TOS is not present on my self-hosted acme which causes the initialization to fail if it's not there. 

As this is actually used **nowhere** in the code, setting it to `None` if not found has little impact and is probably the best option.

Samuel.